### PR TITLE
Upload Temporary Recipe Tarball to a File

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -166,8 +166,15 @@ def remove_volume(payload):
 
 
 @app.task
-def build_image(imageId, imageTag, sourceUrl):
-    """Build docker image from WT Image object and push to a registry."""
+def build_image(imageId, imageTag, sourceUrl, fileId):
+    """
+    Build docker image from WT Image object and push to a registry.
+
+    :param imageId: The ID of the image being built
+    :param imageTag: The full name of the image
+    :param sourceUrl: The path to the repository tarball
+    :param fileId: The id of the file that the repository will end up in
+    """
     def strip_components(members, strip=1):
         for tarinfo in members:
             path = pathlib.Path(tarinfo.path)
@@ -184,6 +191,17 @@ def build_image(imageId, imageTag, sourceUrl):
     urlretrieve(sourceUrl, local_tarball)
     with tarfile.open(local_tarball) as tar:
         tar.extractall(members=strip_components(tar), path=temp_dir)
+        size = os.path.getsize(local_tarball)
+        if fileId is not None:
+            try:
+                cli.uploadFileContents(field=fileId, stream=tar, size=size)
+            except Exception as e:
+                """
+                uploadFileContents can throw Exception-but we want to
+                 continue the building process even if it the upload fails
+                """
+                logging.warning('Failed to upload repository'
+                                ' to Girder. {}'.format(e))
 
     tag = urlparse(REGISTRY_URL).netloc + '/' + imageId
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     },
     install_requires=[
         'girder-client',
+        'girder-worker',
         'docker>=2.3.0',
         'requests'
     ],


### PR DESCRIPTION
Takes a file id and uploads the temporary recipe tarball into it.

Note that this branch shouldn't get merged into master until milestone 0.4 is complete.