### PR TITLE
Convert gwvolman tasks into proper girder jobs

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -133,6 +133,8 @@ def shutdown_container(payload):
     gc, user, instance = _parse_request_body(payload)
 
     cli = docker.from_env(version='1.28')
+    if 'containerInfo' not in instance:
+        return
     containerInfo = instance['containerInfo']  # VALIDATE
     try:
         service = cli.services.get(containerInfo['name'])
@@ -154,6 +156,8 @@ def shutdown_container(payload):
 def remove_volume(payload):
     """Unmount WT-fs and remove mountpoint."""
     gc, user, instance = _parse_request_body(payload)
+    if 'containerInfo' not in instance:
+        return
     containerInfo = instance['containerInfo']  # VALIDATE
 
     cli = docker.from_env(version='1.28')

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -147,7 +147,6 @@ def shutdown_container(payload):
         logging.info("Container [%s] has been released.", service.name)
     except Exception as e:
         logging.error("Unable to release container [%s]: %s", service.id, e)
-        raise
 
 
 @girder_job(title='Remove Tale Data Volume')


### PR DESCRIPTION
* Add `girder_job` decorator to automatically create jobs on girder side and get access to girder token. The latter is not utilized yet.
* Update `payload` for easy task chaining