### PR TITLE
Handle Tale and User Ids Instead of Dicts

### DIFF
--- a/gwvolman/dataone_metadata.py
+++ b/gwvolman/dataone_metadata.py
@@ -248,7 +248,7 @@ def create_minimum_eml(tale,
     description = tale.get('description', str())
     if description is not str():
         abstract = ET.SubElement(dataset, 'abstract')
-        ET.SubElement(abstract, 'para').text = strip_html_tags(description)
+        ET.SubElement(abstract, 'para').text = strip_html_tags(str(description))
 
     # Add a section for the license file
     create_intellectual_rights(dataset, license_id)

--- a/gwvolman/publish.py
+++ b/gwvolman/publish.py
@@ -422,8 +422,6 @@ def create_upload_object_metadata(client, file_object, rights_holder, gc):
         logging.info('Uploaded file to DataONE, PID {}'.format(pid))
     return pid
 
-    return pid
-
 
 def create_upload_repository(tale, client, rights_holder, gc):
     """
@@ -485,7 +483,7 @@ def publish_tale(item_ids,
                  dataone_node,
                  dataone_auth_token,
                  girder_token,
-                 user,
+                 userId,
                  prov_info,
                  license_id):
     """
@@ -507,7 +505,7 @@ def publish_tale(item_ids,
     :param dataone_node: The DataONE member node endpoint
     :param dataone_auth_token: The user's DataONE JWT
     :param girder_token: The user's girder token
-    :param user: The `user` object from /user/me
+    :param userId: The user's ID
     :param prov_info: Additional information included in the tale yaml
     :param license_id: The spdx of the license used
     :type item_ids: list
@@ -515,7 +513,7 @@ def publish_tale(item_ids,
     :type dataone_node: str
     :type dataone_auth_token: str
     :type girder_token: str
-    :type user: dict
+    :type userId: str
     :type prov_info: dict
     :type license_id: str
     :return: The pid of the package's resource map
@@ -529,6 +527,7 @@ def publish_tale(item_ids,
         raise ValueError('Error authenticating with Girder {}'.format(e))
 
     tale = gc.get('/tale/{}/'.format(taleId))
+    user = gc.getUser(userId)
     # create_dataone_client can throw DataONEException
     try:
         """

--- a/gwvolman/publish.py
+++ b/gwvolman/publish.py
@@ -481,7 +481,7 @@ def create_upload_repository(tale, client, rights_holder, gc):
 
 
 def publish_tale(item_ids,
-                 tale,
+                 taleId,
                  dataone_node,
                  dataone_auth_token,
                  girder_token,
@@ -503,7 +503,7 @@ def publish_tale(item_ids,
     the name, description, and ID.
 
     :param item_ids: A list of item ids that are in the package
-    :param tale: The tale structure from /tale/id
+    :param taleId: The tale Id
     :param dataone_node: The DataONE member node endpoint
     :param dataone_auth_token: The user's DataONE JWT
     :param girder_token: The user's girder token
@@ -511,7 +511,7 @@ def publish_tale(item_ids,
     :param prov_info: Additional information included in the tale yaml
     :param license_id: The spdx of the license used
     :type item_ids: list
-    :type tale: dict
+    :type taleId: str
     :type dataone_node: str
     :type dataone_auth_token: str
     :type girder_token: str
@@ -526,8 +526,9 @@ def publish_tale(item_ids,
         gc = girder_client.GirderClient(apiUrl=GIRDER_API_URL)
         gc.token = str(girder_token)
     except Exception as e:
-        raise Exception('ERROR {}'.format(e))
+        raise ValueError('Error authenticating with Girder {}'.format(e))
 
+    tale = gc.get('/tale/{}/'.format(taleId))
     # create_dataone_client can throw DataONEException
     try:
         """
@@ -541,7 +542,6 @@ def publish_tale(item_ids,
                 "Authorization": "Bearer " + dataone_auth_token,
                 "Connection": "close"},
             "user_agent": "safari"})
-
     except DataONEException as e:
         logging.warning('Error creating the DataONE Client: {}'.format(e))
         # We'll want to exit if we can't create the client

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -242,7 +242,7 @@ def publish(item_ids,
     Publishes a Tale to DataONE
 
     :param item_ids: A list of item ids that are in the package
-    :param tale: The tale structure from /tale/id
+    :param tale: The tale id
     :param dataone_node: The DataONE member node endpoint
     :param dataone_auth_token: The user's DataONE JWT
     :param girder_token: The user's girder token
@@ -250,7 +250,7 @@ def publish(item_ids,
     :param prov_info: Additional information included in the tale yaml
     :param license_id: The spdx of the license used
     :type item_ids: list
-    :type tale: dict
+    :type tale: str
     :type dataone_node: str
     :type dataone_auth_token: str
     :type girder_token: str

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -235,7 +235,7 @@ def publish(item_ids,
             dataone_node,
             dataone_auth_token,
             girder_token,
-            user,
+            userId,
             prov_info,
             license_id):
     """
@@ -246,7 +246,7 @@ def publish(item_ids,
     :param dataone_node: The DataONE member node endpoint
     :param dataone_auth_token: The user's DataONE JWT
     :param girder_token: The user's girder token
-    :param user: The `user` object from /user/me
+    :param userId: The user's ID
     :param prov_info: Additional information included in the tale yaml
     :param license_id: The spdx of the license used
     :type item_ids: list
@@ -254,7 +254,7 @@ def publish(item_ids,
     :type dataone_node: str
     :type dataone_auth_token: str
     :type girder_token: str
-    :type user: dict
+    :type userId: str
     :type prov_info: dict
     :type license_id: str
     """
@@ -264,7 +264,7 @@ def publish(item_ids,
                        dataone_node,
                        dataone_auth_token,
                        girder_token,
-                       user,
+                       userId,
                        prov_info,
                        license_id)
     return res

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pyOpenSSL[security]   # bug in pip?
 git+https://github.com/whole-tale/girderfs#egg=girderfs
 requests
 pyyaml
-d1_common
 jwt
 dataone.common
 dataone.libclient


### PR DESCRIPTION
The changes here are for taking the tale and user as IDs and loading the objects internally. 

Lines 529&530 handle the loading of the objects.

There was also a bug fix for tales with empty descriptions.