### PR TITLE
Add a task for streamlined Tale/Instance creation

### DIFF
--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -12,6 +12,12 @@ except socket.gaierror:
 GIRDER_API_URL = os.environ.get('GIRDER_API_URL', DEFAULT_GIRDER_API_URL)
 
 
+class InstanceStatus(object):
+    LAUNCHING = 0
+    RUNNING = 1
+    ERROR = 2
+
+
 class DataONELocations:
     """
     An enumeration that describes the different DataONE

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -1,5 +1,4 @@
 """A set of WT related Girder tasks."""
-from distutils.version import StrictVersion
 import os
 import shutil
 import socket
@@ -21,25 +20,22 @@ from girder_worker.app import app
 # from girder_worker.plugins.docker.executor import _pull_image
 from .utils import \
     HOSTDIR, REGISTRY_USER, REGISTRY_URL, REGISTRY_PASS, \
-    _parse_request_body, new_user, _safe_mkdir, _get_api_key, \
-    _get_container_config, _launch_container
+    new_user, _safe_mkdir, _get_api_key, \
+    _get_container_config, _launch_container, _get_user_and_instance
 from .publish import publish_tale
-from .constants import API_VERSION, GIRDER_API_URL
+from .constants import GIRDER_API_URL
 
 DEFAULT_USER = 1000
 DEFAULT_GROUP = 100
 
 
 @girder_job(title='Create Tale Data Volume')
-@app.task
-def create_volume(payload):
+@app.task(bind=True)
+def create_volume(self, instanceId: str):
     """Create a mountpoint and compose WT-fs."""
-    api_check = payload.get('api_version', '1.0')
-    if StrictVersion(api_check) != StrictVersion(API_VERSION):
-        logging.error('Unsupported API (%s) (server API %s)' %
-                      (api_check, API_VERSION))
+    user, instance = _get_user_and_instance(self.girder_client, instanceId)
+    tale = self.girder_client.get('/tale/{taleId}'.format(**instance))
 
-    gc, user, tale = _parse_request_body(payload)
     vol_name = "%s_%s_%s" % (tale['_id'], user['login'], new_user(6))
     cli = docker.from_env(version='1.28')
 
@@ -53,7 +49,8 @@ def create_volume(payload):
     logging.info("Mountpoint: %s", mountpoint)
 
     try:
-        gc.downloadFolderRecursive(tale['narrativeId'], HOSTDIR + mountpoint)
+        self.girder_client.downloadFolderRecursive(
+            tale['narrativeId'], HOSTDIR + mountpoint)
     except KeyError:
         pass  # no narrativeId
     except girder_client.HttpError:
@@ -76,7 +73,8 @@ def create_volume(payload):
         subprocess.call('mount --bind {}/usr/local /usr/local'.format(libdir),
                         shell=True)
 
-    homeDir = gc.loadOrCreateFolder('Home', user['_id'], 'user')
+    homeDir = self.girder_client.loadOrCreateFolder(
+        'Home', user['_id'], 'user')
     data_dir = os.path.join(mountpoint, 'data')
     _safe_mkdir(HOSTDIR + data_dir)
     home_dir = os.path.join(mountpoint, 'home')
@@ -87,21 +85,22 @@ def create_volume(payload):
     for directory in (data_dir, home_dir, work_dir):
         if not os.path.isdir(directory):
             os.makedirs(directory)
-    api_key = _get_api_key(gc)
+    api_key = _get_api_key(self.girder_client)
 
     if tale.get('folderId'):
         data_set = [
             {'itemId': folder['_id'], 'mountPath': '/' + folder['name']}
-            for folder in gc.listFolder(tale['folderId'])
+            for folder in self.girder_client.listFolder(tale['folderId'])
         ]
         data_set += [
             {'itemId': item['_id'], 'mountPath': '/' + item['name']}
-            for item in gc.listItem(tale['folderId'])
+            for item in self.girder_client.listItem(tale['folderId'])
         ]
-        session = gc.post('/dm/session', parameters={'dataSet': json.dumps(data_set)})
+        session = self.girder_client.post(
+            '/dm/session', parameters={'dataSet': json.dumps(data_set)})
 
-        cmd = "girderfs --hostns -c wt_dms --api-url {} --api-key {} {} {}".format(
-            GIRDER_API_URL, api_key, data_dir, session['_id'])
+        cmd = "girderfs --hostns -c wt_dms --api-url {} --api-key {} {} {}"
+        cmd = cmd.format(GIRDER_API_URL, api_key, data_dir, session['_id'])
         logging.info("Calling: %s", cmd)
         subprocess.call(cmd, shell=True)
     else:
@@ -119,29 +118,25 @@ def create_volume(payload):
     logging.info("Calling: %s", cmd)
     subprocess.call(cmd, shell=True)
 
-    payload.update(
-        dict(
-            nodeId=cli.info()['Swarm']['NodeID'],
-            mountPoint=mountpoint,
-            volumeName=volume.name,
-            sessionId=session['_id']
-        )
+    return dict(
+        nodeId=cli.info()['Swarm']['NodeID'],
+        mountPoint=mountpoint,
+        volumeName=volume.name,
+        sessionId=session['_id'],
+        instanceId=instanceId,
     )
-    return payload
 
 
 @girder_job(title='Spawn Instance')
-@app.task
-def launch_container(payload):
+@app.task(bind=True)
+def launch_container(self, payload):
     """Launch a container using a Tale object."""
-    api_check = payload.get('api_version', '1.0')
-    if StrictVersion(api_check) != StrictVersion(API_VERSION):
-        logging.error('Unsupported API (%s) (server API %s)' %
-                      (api_check, API_VERSION))
+    user, instance = _get_user_and_instance(
+        self.girder_client, payload['instanceId'])
+    tale = self.girder_client.get('/tale/{taleId}'.format(**instance))
 
-    gc, user, tale = _parse_request_body(payload)
-    # _pull_image()
-    container_config = _get_container_config(gc, tale)  # FIXME
+    # _pull_image() #FIXME
+    container_config = _get_container_config(self.girder_client, tale)
     service, attrs = _launch_container(
         payload['volumeName'], payload['nodeId'],
         container_config=container_config)
@@ -165,10 +160,10 @@ def launch_container(payload):
 
 
 @girder_job(title='Shutdown Instance')
-@app.task
-def shutdown_container(payload):
+@app.task(bind=True)
+def shutdown_container(self, instanceId):
     """Shutdown a running Tale."""
-    gc, user, instance = _parse_request_body(payload)
+    user, instance = _get_user_and_instance(self.girder_client, instanceId)
 
     cli = docker.from_env(version='1.28')
     if 'containerInfo' not in instance:
@@ -190,10 +185,11 @@ def shutdown_container(payload):
 
 
 @girder_job(title='Remove Tale Data Volume')
-@app.task
-def remove_volume(payload):
+@app.task(bind=True)
+def remove_volume(self, instanceId):
     """Unmount WT-fs and remove mountpoint."""
-    gc, user, instance = _parse_request_body(payload)
+    user, instance = _get_user_and_instance(self.girder_client, instanceId)
+
     if 'containerInfo' not in instance:
         return
     containerInfo = instance['containerInfo']  # VALIDATE
@@ -205,7 +201,7 @@ def remove_volume(payload):
         subprocess.call("umount %s" % dest, shell=True)
 
     try:
-        gc.delete('/dm/session/{sessionId}'.format(**payload))
+        self.girder_client.delete('/dm/session/{sessionId}'.format(**instance))
     except Exception as e:
         logging.error("Unable to remove session. %s", e)
         pass
@@ -265,7 +261,7 @@ def publish(item_ids,
             prov_info,
             license_id):
     """
-    Publishes a Tale to DataONE
+    Publish a Tale to DataONE.
 
     :param item_ids: A list of item ids that are in the package
     :param tale: The tale id
@@ -284,7 +280,6 @@ def publish(item_ids,
     :type prov_info: dict
     :type license_id: str
     """
-
     res = publish_tale(item_ids,
                        tale,
                        dataone_node,

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -309,8 +309,21 @@ def import_tale(self, imageId: str, dataId: List[str], spawn: bool):
     self.job_manager.updateProgress(
         message='Gathering basic info about the dataset', total=total,
         current=1)
-    dataMap = self.girder_client.get(
-        '/repository/lookup', parameters={'dataId': json.dumps(dataId)})
+    try:
+        dataMap = self.girder_client.get(
+            '/repository/lookup', parameters={'dataId': json.dumps(dataId)})
+    except girder_client.HttpError as resp:
+        try:
+            message = json.loads(resp.responseText).get('message', '')
+        except json.JSONDecodeError:
+            message = str(resp)
+        errormsg = 'Unable to register \"{}\". Server returned {}: {}'
+        errormsg = errormsg.format(dataId[0], resp.status, message)
+        raise ValueError(errormsg)
+
+    if not dataMap:
+        errormsg = 'Unable to register \"{}\". Source is not supported'
+        raise ValueError(errormsg)
 
     self.job_manager.updateProgress(
         message='Registering the dataset in Whole Tale', total=total,

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -19,11 +19,9 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 import docker
-import girder_client
 
 from .constants import \
-    DataONELocations, \
-    GIRDER_API_URL
+    DataONELocations
 
 DOCKER_URL = os.environ.get("DOCKER_URL", "unix://var/run/docker.sock")
 HOSTDIR = os.environ.get("HOSTDIR", "/host")
@@ -80,26 +78,13 @@ def _get_api_key(gc):
     return api_key
 
 
-def _parse_request_body(data):
-    gc = girder_client.GirderClient(apiUrl=data.get('apiUrl', GIRDER_API_URL))
-    gc.token = data['girder_token']
-    user = gc.get('/user/me')
+def _get_user_and_instance(girder_client, instanceId):
+    user = girder_client.get('/user/me')
     if user is None:
         logging.warn("Bad gider token")
         raise ValueError
-
-    if data.get('taleId'):
-        path = '/tale/%s' % data['taleId']
-    elif data.get('instanceId'):
-        path = '/instance/%s' % data['instanceId']
-    else:
-        return gc, user, data
-
-    try:
-        obj = gc.get(path)
-    except girder_client.HttpError as e:
-        raise ValueError
-    return gc, user, obj
+    instance = girder_client.get('/instance/' + instanceId)
+    return user, instance
 
 
 def _get_container_config(gc, tale):


### PR DESCRIPTION
This PR introduces new task that provided `imageId` and `url`:

1. Registers data identified by `url`
2. Creates Tale object using data from 1. and `imageId`
3. Optionally (`spawn=True`) instantiates the Tale.