### PR TITLE
Ensure that a proper CSP_HOSTS is passed to a container

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -20,9 +20,10 @@ from girder_worker.utils import girder_job
 from girder_worker.app import app
 # from girder_worker.plugins.docker.executor import _pull_image
 from .utils import \
-    HOSTDIR, REGISTRY_USER, REGISTRY_URL, REGISTRY_PASS, \
+    HOSTDIR, REGISTRY_USER, REGISTRY_PASS, \
     new_user, _safe_mkdir, _get_api_key, \
-    _get_container_config, _launch_container, _get_user_and_instance
+    _get_container_config, _launch_container, _get_user_and_instance, \
+    DEPLOYMENT
 from .publish import publish_tale
 from .constants import GIRDER_API_URL, InstanceStatus, ENABLE_WORKSPACES, \
     DEFAULT_USER, DEFAULT_GROUP, MOUNTPOINTS
@@ -235,8 +236,8 @@ def build_image(image_id, repo_url, commit_id):
 
     apicli = docker.APIClient(base_url='unix://var/run/docker.sock')
     apicli.login(username=REGISTRY_USER, password=REGISTRY_PASS,
-                 registry=REGISTRY_URL)
-    tag = urlparse(REGISTRY_URL).netloc + '/' + image_id
+                 registry=DEPLOYMENT.registry_url)
+    tag = urlparse(DEPLOYMENT.registry_url).netloc + '/' + image_id
     for line in apicli.build(path=temp_dir, pull=True, tag=tag):
         print(line)
 
@@ -248,7 +249,7 @@ def build_image(image_id, repo_url, commit_id):
 
     cli = docker.from_env(version='1.28')
     cli.login(username=REGISTRY_USER, password=REGISTRY_PASS,
-              registry=REGISTRY_URL)
+              registry=DEPLOYMENT.registry_url)
     image = cli.images.get(tag)
     # Only image.attrs['Id'] is used in Girder right now
     return image.attrs

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -87,6 +87,20 @@ def _get_user_and_instance(girder_client, instanceId):
     return user, instance
 
 
+def get_env_with_csp(config):
+    csp = 'CSP_HOSTS="https://dashboard.{}"'.format(DOMAIN)
+    try:
+        env = config['environment']
+        original_csp = next((_ for _ in env if _.startswith('CSP_HOSTS')), None)
+        if original_csp:
+            env[env.index(original_csp)] = csp
+        else:
+            env.append(csp)
+    except KeyError:
+        env = [csp]
+    return env
+
+
 def _get_container_config(gc, tale):
     if tale is None:
         container_config = {}  # settings['container_config']
@@ -100,7 +114,7 @@ def _get_container_config(gc, tale):
             container_port=tale_config.get('port'),
             container_user=tale_config.get('user'),
             cpu_shares=tale_config.get('cpuShares'),
-            environment=tale_config.get('environment', []),
+            environment=get_env_with_csp(tale_config),
             image=urlparse(REGISTRY_URL).netloc + '/' + tale['imageId'],
             mem_limit=tale_config.get('memLimit'),
             target_mount=tale_config.get('targetMount'),


### PR DESCRIPTION
With this PR we infer dashboard's url directly from docker and construct appropriate CSP_HOSTS env variable, that's subsequently passed to Docker container running Tale instance. It solves multiple annoying issues:

* Manually editing Image objects on each new deployment
* Importing published Tales / Images that would have CSP_HOSTS hardcoded to a place where they were initially created.

Proposed test:
1. Using https://github.com/whole-tale/deploy-dev (branch *dev*), modify `setup_girder.py` so that images are created with wrong CSP_HOSTS setting or even without it.
1. Deploy with `gwvolman` pointing to *master* branch.
1. Run example Tale in the dashboard, to confirm iframes are **not** working
1. Switch `gwvolman` to this branch (*csp_inject*) and restart `celery_worker` via:
   ```
   ./stop_worker.sh && ./run_worker.sh
   ```
1. Re-run example Tale and confirm iframes are working. (Check chrome, firefox, safari)
