### PR TITLE
Mount 'data' inside 'workspace', fixes #38

### DIFF
--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -8,9 +8,10 @@ API_VERSION = '2.1'
 DEFAULT_USER = 1000
 DEFAULT_GROUP = 100
 ENABLE_WORKSPACES = True
-MOUNTPOINTS = ['data', 'home']
 if ENABLE_WORKSPACES:
-    MOUNTPOINTS.append('workspace')
+    MOUNTPOINTS = ['home', 'workspace']
+else:
+    MOUNTPOINTS = ['data', 'home']
 
 try:
     DEFAULT_GIRDER_API_URL = 'http://' + socket.gethostbyname('girder') + ':8080/api/v1'


### PR DESCRIPTION
I took a simplest possible approach:
1. Mount `workspace` -> `workspace_mount/`
2. Create `data` folder inside `workspace` if it doesn't exist
3. Mount `data` -> `workspace_mount/data`

If `data` already exists in the workspace it's going to be overshadowed, which is an intended behavior.
Additionally I would argue that it's going to be near impossible for the user to put any "rogue" data there.

Test scenario:
1. Run a Tale (with external data)
2. Confirm you get:
```
.
├── home
└── workspace
    └── data
```
3. Check that `workspace` is rw, check that `data` is ro.

Note: Changing CWD is out of scope for this PR.