### PR TITLE
Build Tale image using repo2docker

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -344,7 +344,7 @@ def build_tale_image(self, tale_id):
     image = self.girder_client.get('/image/%s' % tale['imageId'])
 
     # TODO: need to configure version of repo2docker
-    repo2docker_version = 'craigwillis/repo2docker:latest'
+    repo2docker_version = 'wholetale/repo2docker:latest'
 
     # Build the image from the workspace
     ret = _build_image(cli, tale_id, image, tag, temp_dir, repo2docker_version)

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -23,7 +23,7 @@ from .utils import \
     HOSTDIR, REGISTRY_USER, REGISTRY_PASS, \
     new_user, _safe_mkdir, _get_api_key, \
     _get_container_config, _launch_container, _get_user_and_instance, \
-    DEPLOYMENT
+    _get_workspace_folder, _build_image, _get_workspace_mtime, DEPLOYMENT
 from .publish import publish_tale
 from .constants import GIRDER_API_URL, InstanceStatus, ENABLE_WORKSPACES, \
     DEFAULT_USER, DEFAULT_GROUP, MOUNTPOINTS
@@ -183,17 +183,17 @@ def update_container(self, instanceId, **kwargs):
         logging.info("Service not present [%s].", containerInfo['name'])
         return
 
-    # Assume containers launched from gwvolman come from its configured registry
-    repoLoc = urlparse(DEPLOYMENT.registry_url).netloc
-    digest = repoLoc + '/' + kwargs['image']
+    digest = kwargs['image']
 
     try:
         # NOTE: Only "image" passed currently, but this can be easily extended
         logging.info("Restarting container [%s].", service.name)
         service.update(image=digest)
-        logging.info("Restart command has been sent to Container [%s].", service.name)
+        logging.info("Restart command has been sent to Container [%s].",
+                     service.name)
     except Exception as e:
-        logging.error("Unable to send restart command to container [%s]: %s", service.id, e)
+        logging.error("Unable to send restart command to container [%s]: %s",
+                      service.id, e)
 
     return {'image_digest': digest}
 
@@ -258,36 +258,111 @@ def remove_volume(self, instanceId):
         pass
 
 
-@girder_job(title='Build WT Image')
-@app.task
-def build_image(image_id, repo_url, commit_id):
-    """Build docker image from WT Image object and push to a registry."""
-    temp_dir = tempfile.mkdtemp()
-    # Clone repository and set HEAD to chosen commitId
-    cmd = 'git clone --recursive {} {}'.format(repo_url, temp_dir)
-    subprocess.call(cmd, shell=True)
-    subprocess.call('git checkout ' + commit_id, shell=True, cwd=temp_dir)
+@girder_job(title='Build Tale Image')
+@app.task(bind=True)
+def build_tale_image(self, tale_id):
+    """
+    Build docker image from Tale workspace using repo2docker
+    and push to Whole Tale registry.
+    """
+    logging.info('Building image for Tale %s', tale_id)
 
-    apicli = docker.APIClient(base_url='unix://var/run/docker.sock')
-    apicli.login(username=REGISTRY_USER, password=REGISTRY_PASS,
-                 registry=DEPLOYMENT.registry_url)
-    tag = urlparse(DEPLOYMENT.registry_url).netloc + '/' + image_id
-    for line in apicli.build(path=temp_dir, pull=True, tag=tag):
-        print(line)
+    tale = self.girder_client.get('/tale/%s' % tale_id)
 
-    # TODO: create tarball
-    # remove clone
-    shutil.rmtree(temp_dir, ignore_errors=True)
-    for line in apicli.push(tag, stream=True):
-        print(line)
+
+    last_build_time = -1
+    try:
+        last_build_time = tale['imageInfo']['last_build']
+    except KeyError:
+        pass
+
+    logging.info('Last build time {}'.format(last_build_time))
+
+    # Only rebuild if files have changed since last build
+    if last_build_time > 0:
+        last_mtime = _get_workspace_mtime(self.girder_client,
+                                          tale['workspaceId'])
+
+        if last_mtime > 0 and last_mtime < last_build_time:
+           logging.info('Workspace not modified since last build. Skipping')
+           return {
+               'image_digest': tale['imageInfo']['digest'], 
+               'repo2docker_version': tale['imageInfo']['repo2docker_version'],
+               'last_build': last_build_time
+           }
+  
+
+    # We're going to try to build. Download the workspace folder.
+    try:
+        temp_dir = tempfile.mkdtemp(dir=HOSTDIR + '/tmp')
+
+        logging.info('Copying workspace contents to %s (%s)', temp_dir,
+                     tale_id)
+
+        workspace = _get_workspace_folder(self.girder_client, tale_id)
+
+        self.girder_client.downloadFolderRecursive(
+            workspace['_id'], temp_dir)
+
+    except Exception as e:
+        raise ValueError('Error accessing Girder: {}'.format(e))
+    except KeyError:
+        logging.info('KeyError')
+        pass  # no workspace folderId
+    except girder_client.HttpError:
+        logging.warn("Workspace folder not found for tale: %s", tale_id)
+        pass
+
 
     cli = docker.from_env(version='1.28')
     cli.login(username=REGISTRY_USER, password=REGISTRY_PASS,
               registry=DEPLOYMENT.registry_url)
+
+    # Use the current time as the image build time and tag
+    build_time = int(time.time())
+
+    tag = '{}/{}/{}'.format(urlparse(DEPLOYMENT.registry_url).netloc,
+                            tale_id, str(build_time))
+
+    # Image is required for config information
+    image = self.girder_client.get('/image/%s' % tale['imageId'])
+
+    # TODO: need to configure version of repo2docker
+    repo2docker_version = 'craigwillis/repo2docker:latest'
+
+    # Build the image from the workspace
+    ret = _build_image(cli, tale_id, image, tag, temp_dir, repo2docker_version)
+
+    # Remove the temporary directory whether the build succeeded or not
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+    if ret['StatusCode'] != 0:
+        # repo2docker build failed
+        raise ValueError('Error building tale {}'.format(tale_id))
+
+    # If the repo2docker build succeeded, push the image to our registry
+    apicli = docker.APIClient(base_url='unix://var/run/docker.sock')
+    apicli.login(username=REGISTRY_USER, password=REGISTRY_PASS,
+                 registry=DEPLOYMENT.registry_url)
+
+    for line in apicli.push(tag, stream=True):
+        print(line.decode('utf-8'))
+
+    # TODO: if push succeeded, delete old image?
+
+    # Get the built image digest
     image = cli.images.get(tag)
     digest = next((_ for _ in image.attrs['RepoDigests']
                    if _.startswith(urlparse(DEPLOYMENT.registry_url).netloc)), None)
-    return {'image_digest': digest}
+
+    logging.info('Successfully built image %s' % image.attrs['RepoDigests'][0])
+
+    # Image digest used by updateBuildStatus handler
+    return {
+        'image_digest': digest, 
+        'repo2docker_version': repo2docker_version,
+        'last_build': build_time
+    }
 
 
 @girder_job(title='Publish Tale')

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -144,6 +144,23 @@ def launch_container(self, payload):
         self.girder_client, payload['instanceId'])
     tale = self.girder_client.get('/tale/{taleId}'.format(**instance))
 
+    if 'imageInfo' not in tale:
+
+        # Wait for image to be built
+        tic = time.time()
+        timeout = 180.0
+
+        while time.time() - tic < timeout:
+
+            logging.info("Waiting for image build to complete.")
+
+            tale = self.girder_client.get('/tale/{taleId}'.format(**instance))
+
+            if 'imageInfo' in tale and 'digest' in tale['imageInfo']:
+                break
+
+            time.sleep(5)
+
     # _pull_image() #FIXME
     container_config = _get_container_config(self.girder_client, tale)
     service, attrs = _launch_container(

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -23,7 +23,7 @@ from .utils import \
     HOSTDIR, REGISTRY_USER, REGISTRY_PASS, \
     new_user, _safe_mkdir, _get_api_key, \
     _get_container_config, _launch_container, _get_user_and_instance, \
-    _get_workspace_folder, _build_image, DEPLOYMENT
+    _build_image, DEPLOYMENT
 from .publish import publish_tale
 from .constants import GIRDER_API_URL, InstanceStatus, ENABLE_WORKSPACES, \
     DEFAULT_USER, DEFAULT_GROUP, MOUNTPOINTS
@@ -315,11 +315,8 @@ def build_tale_image(self, tale_id):
     # Workspace modified so try to build.
     try:
         temp_dir = tempfile.mkdtemp(dir=HOSTDIR + '/tmp')
-
         logging.info('Copying workspace contents to %s (%s)', temp_dir, tale_id)
-
-        workspace = _get_workspace_folder(self.girder_client, tale_id)
-
+        workspace = self.girder_client.get('/folder/{workspaceId}'.format(**tale))
         self.girder_client.downloadFolderRecursive(
             workspace['_id'], temp_dir)
 

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -13,6 +13,7 @@ import uuid
 import logging
 import jwt
 import hashlib
+import dateutil.parser
 
 try:
     from urlparse import urlparse
@@ -188,6 +189,8 @@ def _get_container_config(gc, tale):
         if tale['config']:
             tale_config.update(tale['config'])
 
+        digest=tale['imageInfo']['digest'] or ""
+
         try:
             mem_limit = size_notation_to_bytes(tale_config.get('memLimit', '2g'))
         except (ValueError, TypeError):
@@ -198,7 +201,7 @@ def _get_container_config(gc, tale):
             container_user=tale_config.get('user'),
             cpu_shares=tale_config.get('cpuShares'),
             environment=get_env_with_csp(tale_config),
-            image=urlparse(DEPLOYMENT.registry_url).netloc + '/' + tale['imageId'],
+            image=digest,
             mem_limit=mem_limit,
             target_mount=tale_config.get('targetMount'),
             url_path=tale_config.get('urlPath')
@@ -623,3 +626,87 @@ def find_initial_pid(path):
         return 'doi:{}'.format(doi.group())
     else:
         return path
+
+def _get_workspace_folder(gc, tale_id):
+    """
+    Get the workspace folder for the specified tale
+    """
+    user = gc.get('/user/me')
+
+    path = '/collection/WholeTale Workspaces/WholeTale Workspaces'
+    parent = gc.get('resource/lookup',
+                    parameters={'path': path})
+
+    workspace = gc.get(
+        '/folder',
+        parameters={
+            'parentId': parent['_id'],
+            'parentType': 'folder',
+            'name': tale_id
+        },
+    )
+    return workspace[0]
+
+def _build_image(cli, tale_id, image, tag, temp_dir, repo2docker_version):
+    """
+    Run repo2docker on the workspace using a shared temp directory. Note that
+    this uses the "local" provider.  Use the same default user-id and
+    user-name as BinderHub
+    """  
+    r2d_cmd = ('jupyter-repo2docker '
+               '--target-repo-dir="/home/jovyan/work/workspace" '
+               '--template={} --buildpack-name={} '
+               '--user-id=1000 --user-name={} '
+               '--no-clean --no-run --debug '
+               '--image-name {} {}'.format(
+                                           image['config']['template'],
+                                           image['config']['buildpack'],
+                                           image['config']['user'],
+                                           tag, temp_dir))
+
+    logging.debug('Calling %s (%s)', r2d_cmd, tale_id)
+
+    container = cli.containers.run(
+        image=repo2docker_version,
+        command=r2d_cmd,
+        environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
+        privileged=True,
+        detach=True,
+        remove=True,
+        volumes={
+            '/var/run/docker.sock': {
+                'bind': '/var/run/docker.sock', 'mode': 'rw'
+            },
+            '/tmp': {
+                'bind': '/host/tmp', 'mode': 'ro'
+            }
+        }
+    )
+
+    # Job output must come from stdout/stderr
+    for line in container.logs(stream=True):
+        print(line.decode('utf-8'))
+
+    # Since detach=True, then we need to explicitly check for the
+    # container exit code
+    return container.wait()
+
+def _get_workspace_mtime(gc, workspace_id):
+    """
+    Return -1 or the last modification time of files in the root
+    of the workspace. This is used to determine whether to try to 
+    rebuild the image.
+ 
+    mtime is only present after modification
+    """
+    last_mtime = -1
+    for file in gc.get('/folder/{}/listing'.format(workspace_id))['files']:
+        if 'mtime' in file:
+           mtime = file['mtime']
+        else:
+           # 2019-03-10T01:44:34.509000+00:00
+           mtime = dateutil.parser.parse(file['created']).timestamp()
+
+        if mtime > last_mtime:
+           last_mtime = mtime
+    return last_mtime

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -627,26 +627,6 @@ def find_initial_pid(path):
     else:
         return path
 
-def _get_workspace_folder(gc, tale_id):
-    """
-    Get the workspace folder for the specified tale
-    """
-    user = gc.get('/user/me')
-
-    path = '/collection/WholeTale Workspaces/WholeTale Workspaces'
-    parent = gc.get('resource/lookup',
-                    parameters={'path': path})
-
-    workspace = gc.get(
-        '/folder',
-        parameters={
-            'parentId': parent['_id'],
-            'parentType': 'folder',
-            'name': tale_id
-        },
-    )
-    return workspace[0]
-
 def _build_image(cli, tale_id, image, tag, temp_dir, repo2docker_version):
     """
     Run repo2docker on the workspace using a shared temp directory. Note that

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -690,23 +690,3 @@ def _build_image(cli, tale_id, image, tag, temp_dir, repo2docker_version):
     # Since detach=True, then we need to explicitly check for the
     # container exit code
     return container.wait()
-
-def _get_workspace_mtime(gc, workspace_id):
-    """
-    Return -1 or the last modification time of files in the root
-    of the workspace. This is used to determine whether to try to 
-    rebuild the image.
- 
-    mtime is only present after modification
-    """
-    last_mtime = -1
-    for file in gc.get('/folder/{}/listing'.format(workspace_id))['files']:
-        if 'mtime' in file:
-           mtime = file['mtime']
-        else:
-           # 2019-03-10T01:44:34.509000+00:00
-           mtime = dateutil.parser.parse(file['created']).timestamp()
-
-        if mtime > last_mtime:
-           last_mtime = mtime
-    return last_mtime

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -189,7 +189,7 @@ def _get_container_config(gc, tale):
         if tale['config']:
             tale_config.update(tale['config'])
 
-        digest=tale['imageInfo']['digest'] or ""
+        digest=tale['imageInfo']['digest'] 
 
         try:
             mem_limit = size_notation_to_bytes(tale_config.get('memLimit', '2g'))


### PR DESCRIPTION
Fixes #40.  See https://github.com/whole-tale/girder_wholetale/pull/211 for test case.  

This PR requires:
* https://github.com/whole-tale/girder_wholetale/pull/211 
* https://github.com/craig-willis/repo2docker/pull/1 for WT customizations to `repo2docker`

This PR does the following:
* Refactors `build_image to `build_tale_image` to run `repo2docker` on the Tale workspace
* Downloads Tale workspace folder via `girder_client.downloadFolderRecursive` to temp directory
* Builds the image using `repo2docker`
* Removes temp directory
* Pushes image to registry
* Returns image digest for use in instance creation

There are a few open issues:
* How to handle `repo2docker` version pinning
* How to handle commit-hash.  For now, append the time, but we'll have tag proliferation. Need a way to determine if the workspace changed or if relevant files in the workspace changed.

Related repo2docker issues:
* https://github.com/jupyter/repo2docker/issues/490
* https://github.com/jupyter/repo2docker/issues/546
* https://github.com/jupyter/repo2docker/issues/545
* https://github.com/jupyter/repo2docker/issues/533
