### PR TITLE
Added a new task for updating a running container's image

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -281,8 +281,9 @@ def build_image(image_id, repo_url, commit_id):
     cli.login(username=REGISTRY_USER, password=REGISTRY_PASS,
               registry=DEPLOYMENT.registry_url)
     image = cli.images.get(tag)
-    # Only image.attrs['Id'] is used in Girder right now
-    return image.attrs
+    digest = next((_ for _ in image.attrs['RepoDigests']
+               if _.startswith(urlparse(DEPLOYMENT.registry_url).netloc)), None)
+    return {'image_digest': digest}
 
 
 @girder_job(title='Publish Tale')

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -181,17 +181,17 @@ def update_container(self, instanceId, **kwargs):
     
     # Assume containers launched from gwvolman come from its configured registry
     repoLoc = urlparse(DEPLOYMENT.registry_url).netloc
-    newImageString = repoLoc + '/' + kwargs['image']
+    digest = repoLoc + '/' + kwargs['image']
     
     try:
         # NOTE: Only "image" passed currently, but this can be easily extended
         logging.info("Restarting container [%s].", service.name)
-        service.update(image=newImageString)
+        service.update(image=digest)
         logging.info("Restart command has been sent to Container [%s].", service.name)
     except Exception as e:
         logging.error("Unable to send restart command to container [%s]: %s", service.id, e)
         
-    return { 'image': newImageString }
+    return { 'image_digest': digest }
 
 
 @girder_job(title='Shutdown Instance')

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -181,14 +181,17 @@ def update_container(self, instanceId, **kwargs):
     
     # Assume containers launched from gwvolman come from its configured registry
     repoLoc = urlparse(DEPLOYMENT.registry_url).netloc
+    newImageString = repoLoc + '/' + kwargs['image']
     
     try:
         # NOTE: Only "image" passed currently, but this can be easily extended
         logging.info("Restarting container [%s].", service.name)
-        service.update(image=repoLoc + '/' + kwargs['image'])
+        service.update(image=newImageString)
         logging.info("Restart command has been sent to Container [%s].", service.name)
     except Exception as e:
         logging.error("Unable to send restart command to container [%s]: %s", service.id, e)
+        
+    return { 'image': newImageString }
 
 
 @girder_job(title='Shutdown Instance')


### PR DESCRIPTION
# Problem
Fixes #41 - when a Tale is rebuilt, we need a way for the user to signal to the underlying instance that it should be restarted with the newest image.

Relates to https://github.com/whole-tale/girder_wholetale/pull/212

# Approach
Add a general `update_container` task that can be easily expanded to cover additional related functionality, as needed.

# How to Test
There is currently not a super clean way to test this, as it currently requires running this code alongside the code from another PR to `girder_wholetale`.

So here goes:
1. Run [`deploy-dev`](https://github.com/whole-tale/deploy-dev/tree/dev) stack using the provided README instructions (make sure to use `dev` branch for now)
2. `cd src/gwvolman`, `git fetch --all`, and checkout this branch
    * NOTE: You may need to restart the worker with `make restart_worker`
3. `cd ../../src/wholetale`, `git fetch --all`, and checkout the `add_new_rest_endpoint_put_instance` branch
    * NOTE: Girder will restart automatically restart itself and rebuild the WholeTale plugin
4. Navigate to SwaggerUI to find the new [`PUT /instance/:id` endpoint](https://girder.local.wholetale.org/api/v1#!/instance/instance_updateInstance)
5. Lookup the ID of an instance, enter it into the input field provided, and click "Try it out"
    * Your request should return 200 and the response is the instance you just PUT
6. Check `docker logs -f celery_worker`
    * You should see a line in the logs saying that the `update_container` task has succeeded
7. Check `docker ps` and/or `docker service ls`
    * ~~XXX: This is currently broken, due to a digest mismatch (see https://github.com/whole-tale/gwvolman/pull/44#issuecomment-454548260)~~
    * You should see that your instance has been recreated
    * NOTE: If the underlying image has changed, it may take one or more minutes to restart

