### PR TITLE
Disable use of locks for davfs. Fixes #51

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,10 @@ RUN sed \
   -e 's/return decode(data/&.decode("utf-8")/' \
   -i /usr/local/lib/python3.5/dist-packages/kombu/serialization.py
 
+# https://github.com/whole-tale/gwvolman/issues/51
+# https://github.com/whole-tale/wt_home_dirs/issues/18
+RUN echo "use_locks 0" >> /etc/davfs2/davfs2.conf && \
+  echo "backup_dir .lost+found" >> /etc/davfs2/davfs2.conf && \
+  echo "gui_optimize 1" >> /etc/davfs2/davfs2.conf
+
 ENTRYPOINT ["python3", "-m", "girder_worker", "-l", "INFO"]


### PR DESCRIPTION
Per davfs2 man:

```
use_locks
   Whether to lock files on the server when they are opened for writing. 0 = no, 1 = yes.

gui_optimize
   When a file is opened, mount.davfs will have to check the server whether there is a newer version. 
   Graphical User Interfaces tend to open just any file, slowing down things dramatically for large 
   directories. With this option mount.davfs will try to get this information from all files in a directory with 
   one PROPFIND request. 0 = no, 1 = yes.
   Default: 0
```

makes UX more smooth at the cost of (possible?) data corruption. We should send a clear message to the users that multiple concurrent, intensive and distributed i/o workloads on webdav mounts are a bad idea...

As a bonus, we are hiding `lost+found` by prefixing it with a `.`.