### PR TITLE
Check DataONE Mimetypes

### DIFF
--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -52,14 +52,13 @@ class DataONEMetadata(object):
         If a mimeType isn't found in DataONE's supported list,
         default to application/octet-stream.
 
-        :param supported_types:
-        :param mimetype:
-        :return:
+        :param mimetype: The mimetype in question
+        :type mimetype: str
+        :return: A mimetype that is supported by DataONE
         """
 
         if not self.mimetypes:
             self.mimetypes = self.get_dataone_mimetypes()
-
         if mimetype not in self.mimetypes:
             return 'application/octet-stream'
         return mimetype

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -152,7 +152,7 @@ class DataONEPublishProvider(PublishProvider):
                         file_pid = client.generateIdentifier(scheme="UUID").value()
 
                         mimeType = metadata.get_dataone_mimetype(
-                            mimetypes.guess_type(fpath))
+                            mimetypes.guess_type(fpath)[0])
 
                         if fname == 'manifest.json':
                             size, hash = manifest_size, manifest_md5


### PR DESCRIPTION
This fixes the issue described in issue #57 and should suffice for issue #48.
`mimetypes.guess_type` returns a tuple which was getting sent to `get_dataone_mimetype`, causing it to return `application/octet-stream`. 