### PR TITLE
Use new schema for authors field in "Analyze in WT" (whole-tale/girder_wholetale#273)

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -481,7 +481,7 @@ def import_tale(self, lookup_kwargs, tale_kwargs, spawn=True):
 
     user = self.girder_client.get('/user/me')
     payload = {
-        'authors': user['firstName'] + ' ' + user['lastName'],
+        'authors': [],
         'title': 'A Tale for \"{}\"'.format(shortened_name),
         'dataSet': [
             {


### PR DESCRIPTION
`import_tale` was using outdated schema, which broke this functionality. Instead of trying to set `authors` based on person who's creating a Tale, we're setting it to an empty list to avoid problems during potential publishing.

### How to test?
1. Deploy locally
2. Add ["http://dev2.dataverse.org"] to list of Extra Dataverse Installations (https://girder.local.wholetale.org/#plugins/wholetale/config)
3. Try creating tale by following: https://dashboard.local.wholetale.org/compose?uri=http%3A%2F%2Fdev2.dataverse.org%2Fapi%2Faccess%2Fdatafile%2F29