### PR TITLE
Switch from using the environmental variable CN. Fixes #71

### DIFF
--- a/gwvolman/lib/dataone/constants.py
+++ b/gwvolman/lib/dataone/constants.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
-
-DATAONE_URL = os.environ.get('DATAONE_URL',
-                             'https://cn-stage-2.test.dataone.org/cn')
 
 
 class DataONELocations:

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -29,8 +29,8 @@ class DataONEMetadata(object):
     mimetypes = set()
     access_policy = None
 
-    def __init__(self, coordinating_node_url):
-        self.coordinating_node = coordinating_node_url
+    def __init__(self, coordinating_node):
+        self.coordinating_node = coordinating_node
 
     def get_dataone_mimetypes(self):
         """
@@ -39,7 +39,7 @@ class DataONEMetadata(object):
         :return: A list of mimetypes
         :rtype: list
         """
-        response = urlopen(self.coordinating_node+'/v2/formats')
+        response = urlopen(self.coordinating_node+'/formats')
         e = ET.ElementTree(ET.fromstring(response.read()))
         root = e.getroot()
         mime_types = set()

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -11,8 +11,7 @@ except ImportError:
 
 from .constants import \
     ExtraFileNames, \
-    file_descriptions, \
-    DATAONE_URL
+    file_descriptions
 
 from d1_common.types import dataoneTypes
 from d1_common import const as d1_const
@@ -30,6 +29,9 @@ class DataONEMetadata(object):
     mimetypes = set()
     access_policy = None
 
+    def __init__(self, coordinating_node_url):
+        self.coordinating_node = coordinating_node_url
+
     def get_dataone_mimetypes(self):
         """
         Returns a list of DataONE supported mimetypes. The endpoint returns
@@ -37,7 +39,7 @@ class DataONEMetadata(object):
         :return: A list of mimetypes
         :rtype: list
         """
-        response = urlopen(DATAONE_URL+'/v2/formats')
+        response = urlopen(self.coordinating_node+'/v2/formats')
         e = ET.ElementTree(ET.fromstring(response.read()))
         root = e.getroot()
         mime_types = set()
@@ -105,7 +107,7 @@ class DataONEMetadata(object):
         :rtype: d1_common.resource_map.ResourceMap
         """
 
-        ore = ResourceMap(base_url=DATAONE_URL+'/cn')
+        ore = ResourceMap(base_url=self.coordinating_node)
         ore.oreInitialize(pid)
         ore.addMetadataDocument(scimeta_pid)
         ore.addDataDocuments(sciobj_pid_list, scimeta_pid)

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -16,6 +16,7 @@ except ImportError:
 
 from d1_client.mnclient_2_0 import MemberNodeClient_2_0
 from d1_common.types.exceptions import DataONEException, InvalidToken
+from d1_common.env import D1_ENV_DICT
 
 from .metadata import DataONEMetadata
 
@@ -49,7 +50,7 @@ class DataONEPublishProvider(PublishProvider):
             logging.warning(e)
             raise ValueError('Failed to establish connection with DataONE.')
 
-    def publish(self, tale_id, gc, dataone_node, dataone_auth_token,
+    def publish(self, tale_id, gc, dataone_node, dataone_auth_token, is_production,
                 job_manager=None):
         """
         Workhorse method that downloads a zip file for a tale then
@@ -75,6 +76,11 @@ class DataONEPublishProvider(PublishProvider):
             logging.warning(e)
             # We'll want to exit if we can't create the client
             raise ValueError('Failed to establish connection with DataONE.')
+
+        # Set the coordinating node
+        coordinating_node_url = D1_ENV_DICT['dev']['base_url']
+        if is_production:
+            D1_ENV_DICT['prod']['base_url']
 
         user_id, full_orcid_name = self._extract_user_info(dataone_auth_token)
         if not all([user_id, full_orcid_name]):
@@ -130,7 +136,7 @@ class DataONEPublishProvider(PublishProvider):
                     total=100, current=int(step/steps*100))
             step += 1
 
-            metadata = DataONEMetadata()
+            metadata = DataONEMetadata(coordinating_node_url)
             # Create an EML document based on the manifest
             eml_pid = self._generate_pid(client)
             eml_doc = metadata.create_eml_doc(

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -423,15 +423,18 @@ def publish(self,
             tale,
             dataone_node,
             dataone_auth_token,
+            is_production,
             user_id):
     """
     :param tale: The tale id
     :param dataone_node: The DataONE member node endpoint
     :param dataone_auth_token: The user's DataONE JWT
+    :param is_production: Flag set to true when publishing to a production server
     :param user_id: The user's ID
     :type tale: str
     :type dataone_node: str
     :type dataone_auth_token: str
+    :type is_production: bool
     :type user_id: str
     """
 
@@ -441,6 +444,7 @@ def publish(self,
                  self.girder_client,
                  dataone_node,
                  dataone_auth_token,
+                 is_production,
                  self.job_manager
     )
 

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -423,18 +423,18 @@ def publish(self,
             tale,
             dataone_node,
             dataone_auth_token,
-            is_production,
+            coordinating_node,
             user_id):
     """
     :param tale: The tale id
     :param dataone_node: The DataONE member node endpoint
     :param dataone_auth_token: The user's DataONE JWT
-    :param is_production: Flag set to true when publishing to a production server
+    :param coordinating_node: URL to the coordinating node
     :param user_id: The user's ID
     :type tale: str
     :type dataone_node: str
     :type dataone_auth_token: str
-    :type is_production: bool
+    :type coordinating_node: str
     :type user_id: str
     """
 
@@ -444,7 +444,7 @@ def publish(self,
                  self.girder_client,
                  dataone_node,
                  dataone_auth_token,
-                 is_production,
+                 coordinating_node,
                  self.job_manager
     )
 


### PR DESCRIPTION
This PR removes the environmental variable for the CN and uses the DataONE Python library to keep track of them.

I added a variable to the publishing task to help us figure out which CN to use.

To test:
I accidentally published to production with this code, so try to avoid that.
1. Check this branch out
2. Check [add_prod_publishing_flag](https://github.com/whole-tale/girder_wholetale/pull/301) out
3. Check [dataone_login_refacor](https://github.com/whole-tale/dashboard/pull/474) out
4. Try to publish to dataone dev
5. You should get a valid package

Attached to issue #72 