### PR TITLE
Generate UUIDs for everthing except the EML document

### DIFF
--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -151,8 +151,7 @@ class DataONEPublishProvider(PublishProvider):
                                 total=100, current=int(step/steps*100))
                         step += 1
 
-                        # Generate uuid (TODO: Replace with D1 API call)
-                        file_pid = self._generate_pid(client)
+                        file_pid = self._generate_pid(client, scheme='UUID')
 
                         mimeType = metadata.get_dataone_mimetype(
                             mimetypes.guess_type(fpath)[0])
@@ -212,7 +211,7 @@ class DataONEPublishProvider(PublishProvider):
                 step += 1
 
                 # Create ORE
-                res_pid = self._generate_pid(client)
+                res_pid = self._generate_pid(client, scheme='UUID')
                 res_map = metadata.create_resource_map(
                     res_pid, eml_pid, uploaded_pids)
                 res_meta = metadata.generate_system_metadata(


### PR DESCRIPTION
Linked to issue #73 

This PR switches to assigning DataONE internal identifiers for files, but leaves a DOI for the EML document. An example dataset can be found [here](https://dev.nceas.ucsb.edu/view/urn:uuid:6bcd52d0-ae8e-4cfe-89f0-b013205760a8). Note how the DOI is at the end of the title, and is listed under `identifier` in the "General" section.

I removed the TODO comment because the d1 python library is using the API under the hood.

To Test:
1. Check this branch out
2. Publish a Tale to DataONE development
3. Make sure that the package URL is _not_ a doi
4. Note that a doi is listed as the package identifier and is in the title