### PR TITLE
Integrate with new repo2docker_wholetale extension

### DIFF
--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -18,6 +18,8 @@ except socket.gaierror:
     DEFAULT_GIRDER_API_URL = 'https://girder.dev.wholetale.org/api/v1'
 GIRDER_API_URL = os.environ.get('GIRDER_API_URL', DEFAULT_GIRDER_API_URL)
 
+REPO2DOCKER_VERSION = 'wholetale/repo2docker_wholetale:latest'
+
 
 class InstanceStatus(object):
     LAUNCHING = 0

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -29,7 +29,7 @@ from .utils import \
 from .lib.dataone.publish import DataONEPublishProvider
 
 from .constants import GIRDER_API_URL, InstanceStatus, ENABLE_WORKSPACES, \
-    DEFAULT_USER, DEFAULT_GROUP, MOUNTPOINTS
+    DEFAULT_USER, DEFAULT_GROUP, MOUNTPOINTS, REPO2DOCKER_VERSION
 
 CREATE_VOLUME_STEP_TOTAL = 2
 LAUNCH_CONTAINER_STEP_TOTAL = 2
@@ -421,11 +421,12 @@ def build_tale_image(task, tale_id):
     # Image is required for config information
     image = task.girder_client.get('/image/%s' % tale['imageId'])
 
-    # TODO: need to configure version of repo2docker
-    repo2docker_version = 'wholetale/repo2docker:latest'
+    # Write the environment.json to the workspace
+    with open(os.path.join(temp_dir, 'environment.json'), 'w') as fp:
+        json.dump(image, fp)
 
     # Build the image from the workspace
-    ret = _build_image(cli, tale_id, image, tag, temp_dir, repo2docker_version)
+    ret = _build_image(cli, tale_id, image, tag, temp_dir, REPO2DOCKER_VERSION)
 
     # Remove the temporary directory whether the build succeeded or not
     shutil.rmtree(temp_dir, ignore_errors=True)
@@ -460,7 +461,7 @@ def build_tale_image(task, tale_id):
     # Image digest used by updateBuildStatus handler
     return {
         'image_digest': digest,
-        'repo2docker_version': repo2docker_version,
+        'repo2docker_version': REPO2DOCKER_VERSION,
         'last_build': build_time
     }
 

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -290,17 +290,15 @@ def _build_image(cli, tale_id, image, tag, temp_dir, repo2docker_version):
     user-name as BinderHub
     """
     r2d_cmd = ('jupyter-repo2docker '
+               '--config="/wholetale/repo2docker_config.py" '
                '--target-repo-dir="/home/jovyan/work/workspace" '
-               '--template={} --buildpack-name={} '
                '--user-id=1000 --user-name={} '
                '--no-clean --no-run --debug '
                '--image-name {} {}'.format(
-                                           image['config']['template'],
-                                           image['config']['buildpack'],
                                            image['config']['user'],
                                            tag, temp_dir))
 
-    logging.debug('Calling %s (%s)', r2d_cmd, tale_id)
+    logging.info('Calling %s (%s)', r2d_cmd, tale_id)
 
     container = cli.containers.run(
         image=repo2docker_version,


### PR DESCRIPTION
The new https://github.com/whole-tale/repo2docker_wholetale repository implements WT images (Jupyter, Jupyter + Spark, Rocker, OpenRefine) via custom build packs using the model discussed in https://github.com/jupyter/repo2docker/issues/487#issuecomment-479794426.

This PR changes the gwvolman build_tale task to use the new approach.  In short, an `environment.json` is injected into the workspace at image build time. This file contains information needed to select the correct build pack.   This PR also moves the repo2docker image version to a constant for use in the girder_wholetale plugin (https://github.com/whole-tale/girder_wholetale/pull/308).

To test (via deploy-dev):
* Checkout this gwvolman branch
* `docker logs -f celery_worker`
* Compose new tale using RStudio (rocker geospatial)
* Confirm that you see the following in the `celery_worker` logs:
```
[2019-06-05 18:57:11,603: WARNING/ForkPoolWorker-1] Using RockerWTStackBuildPack builder
[2019-06-05 18:57:11,653: WARNING/ForkPoolWorker-1] Step 1/26 : FROM rocker/geospatial:3.5.1
```

