### PR TITLE
Label services with Instance/Tale Id

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -186,7 +186,8 @@ def launch_container(self, payload):
     container_config = _get_container_config(self.girder_client, tale)
     service, attrs = _launch_container(
         payload['volumeName'], payload['nodeId'],
-        container_config=container_config)
+        container_config,
+        tale_id=tale['_id'], instance_id=payload['instanceId'])
 
     tic = time.time()
     timeout = 30.0

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -208,7 +208,7 @@ def _get_container_config(gc, tale):
     return container_config
 
 
-def _launch_container(volumeName, nodeId, container_config):
+def _launch_container(volumeName, nodeId, container_config, tale_id='', instance_id=''):
 
     token = uuid.uuid4().hex
     # command
@@ -261,7 +261,9 @@ def _launch_container(volumeName, nodeId, container_config):
             'traefik.frontend.rule': 'Host:{}.{}'.format(host, DOMAIN),
             'traefik.docker.network': DEPLOYMENT.traefik_network,
             'traefik.frontend.passHostHeader': 'true',
-            'traefik.frontend.entryPoints': TRAEFIK_ENTRYPOINT
+            'traefik.frontend.entryPoints': TRAEFIK_ENTRYPOINT,
+            'wholetale.instanceId': instance_id,
+            'wholetale.taleId': tale_id,
         },
         env=container_config.environment,
         mode=docker.types.ServiceMode('replicated', replicas=1),


### PR DESCRIPTION
Have you ever run a Tale and something went awfully wrong? Have you ever spent egregious amount of time trying to figure out where the heck it was running to see what happened? Fret no more! With this fabulous PR soon you'll be able to do it in a flash! Behold amazing docker magic:

```
docker service ps $(docker service ls -f label=wholetale.instanceId=5cfeac6f72ef511908fcc612 -q)
```

### How to test?
1. Run a Tale.
1. `docker inspect` Tale container and confirm that `wholetale.instanceId` and `wholetale.taleId` are set.