### PR TITLE
Strip EOL from docker logs

### DIFF
--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -319,7 +319,7 @@ def _build_image(cli, tale_id, image, tag, temp_dir, repo2docker_version):
 
     # Job output must come from stdout/stderr
     for line in container.logs(stream=True):
-        print(line.decode('utf-8'))
+        print(line.decode('utf-8').strip())
 
     # Since detach=True, then we need to explicitly check for the
     # container exit code


### PR DESCRIPTION
This removes spurious line breaks from job logs from image builds.

### How to test?
1. Deploy locally and register Ligo tale.
2. Run Ligo tale.
3. Click on "View logs" in the notification panel during image build and confirm that log is nice and tidy.