### PR TITLE
Upload a subset of the exported bag to DataONE

### DIFF
--- a/gwvolman/lib/dataone/constants.py
+++ b/gwvolman/lib/dataone/constants.py
@@ -15,15 +15,16 @@ class DataONELocations:
 
 class ExtraFileNames:
     """
-    When creating data packages we'll have to create additional files, such as
-    the zipped recipe, the tale.yml file, the metadata document, and possibly
-    more. Keep their names store here so that they can easily be referenced and
-    changed in a single place.
+    There are a couple of extra files that we generate when creating
+    the bag that gets uploaded to DataONE. Keep track of their filenames
+    here.
     """
     # Name for the tale config file
     manifest_file = 'manifest.json'
     license_filename = 'LICENSE'
     environment_file = 'environment.json'
+    fetch_file = 'fetch.txt'
+    run_local_file = 'run-local.sh'
 
 
 """
@@ -37,5 +38,11 @@ file_descriptions = {
         'A configuration file, holding information that is needed to '
         'reproduce the compute environment.',
     ExtraFileNames.license_filename:
-        'The package\'s licensing information.'
+        'The package\'s licensing information.',
+    ExtraFileNames.fetch_file:
+        'Contains references to external data that needs to be downloaded '
+        'before running the Tale',
+    ExtraFileNames.run_local_file:
+        'A bash script that downloads the neccessary external data and then runs '
+        'the Tale.'
 }

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -238,14 +238,20 @@ class DataONEMetadata(object):
         userid_elem.set('directory', self._get_directory(user_id))
 
     def create_eml_doc(self, eml_pid, manifest, user_id, manifest_size,
-                       environment_size, license_text):
+                       environment_size, run_local_size, fetch_size,
+                       license_text):
         """
-        Creates an initial EML record for the package based on a manifest.
+                Creates an initial EML record for the package based on a manifest.
         Individual objects will be added after-the-fact.
-
-        :param manifest: Tale manifest
-        :type manifest: dict
-        :return: etree object
+        :param eml_pid: The pid of the EML document
+        :param manifest: The manifest document
+        :param user_id: The ORCID of the publisher
+        :param manifest_size: The size of the manifest
+        :param environment_size: The size of the environment
+        :param run_local_size: The size of the run-local script
+        :param fetch_size: The size of the fetch file
+        :param license_text: The text of the license file
+        :return: ETree
         """
 
         # Create the namespace
@@ -328,6 +334,17 @@ class DataONEMetadata(object):
         description = file_descriptions[ExtraFileNames.environment_file]
         self.add_object_record(dataset_elem, name, description,
                                environment_size, 'application/json')
+
+
+        # Add the run-local.sh file
+        description = file_descriptions[ExtraFileNames.run_local_file]
+        self.add_object_record(dataset_elem, ExtraFileNames.run_local_file, description,
+                               run_local_size, 'application/octet-stream')
+        # Add the fetch.txt file
+        description = file_descriptions[ExtraFileNames.fetch_file]
+        self.add_object_record(dataset_elem, ExtraFileNames.fetch_file, description,
+                               fetch_size, 'text/plain')
+
 
         """
         Emulate the behavior of ElementTree.tostring in Python 3.6.0

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -273,7 +273,6 @@ class DataONEMetadata(object):
         dataset_elem = ET.SubElement(ns, 'dataset')
         ET.SubElement(dataset_elem, 'title').text = manifest['schema:name']
 
-
         """
         Create a `creator` section for each Tale author.
         """
@@ -293,14 +292,12 @@ class DataONEMetadata(object):
             contact_email = manifest['createdBy']['schema:email']
             self.set_user_name(creator_elem, first_name, last_name, contact_email)
 
-
         # Create a `description` field, but only if the Tale has a description.
         description = manifest['schema:description']
         if description is not str():
             abstract_elem = ET.SubElement(dataset_elem, 'abstract')
             ET.SubElement(abstract_elem, 'para').text = \
                 self._strip_html_tags(str(description))
-
 
         # Add a section for the license file
         self.create_intellectual_rights(dataset_elem, license_text)
@@ -335,7 +332,6 @@ class DataONEMetadata(object):
         self.add_object_record(dataset_elem, name, description,
                                environment_size, 'application/json')
 
-
         # Add the run-local.sh file
         description = file_descriptions[ExtraFileNames.run_local_file]
         self.add_object_record(dataset_elem, ExtraFileNames.run_local_file, description,
@@ -344,7 +340,6 @@ class DataONEMetadata(object):
         description = file_descriptions[ExtraFileNames.fetch_file]
         self.add_object_record(dataset_elem, ExtraFileNames.fetch_file, description,
                                fetch_size, 'text/plain')
-
 
         """
         Emulate the behavior of ElementTree.tostring in Python 3.6.0

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -64,6 +64,10 @@ class DataONEPublishProvider(PublishProvider):
         step = 1
         steps = 100
 
+        # Files to ignore when uploading
+        ignore_files = ['tagmanifest-sha256.txt', 'tagmanifest-md5.txt',
+                        'manifest-sha256.txt', 'manifest-md5.txt',
+                        'bag-info.txt', 'bagit.txt']
         if job_manager:
             job_manager.updateProgress(
                 message='Connecting to {}'.format(dataone_node),
@@ -89,7 +93,7 @@ class DataONEPublishProvider(PublishProvider):
         step += 1
 
         # Export the tale to a temp directory
-        url = 'tale/{}/export'.format(tale_id)
+        url = 'tale/{}/export?taleFormat=bagit'.format(tale_id)
         stream = gc.sendRestRequest('get', url, stream=True, jsonResp=False)
         with tempfile.NamedTemporaryFile(delete=False, suffix='.zip') as tmp:
 
@@ -114,7 +118,7 @@ class DataONEPublishProvider(PublishProvider):
                 manifest = json.loads(data.decode('utf-8'))
 
             # Read the license text
-            license_path = '{}/LICENSE'.format(tale_id)
+            license_path = '{}/data/LICENSE'.format(tale_id)
             with zip.open(license_path) as f:
                 license_text = str(f.read().decode('utf-8'))
 
@@ -124,6 +128,20 @@ class DataONEPublishProvider(PublishProvider):
             with zip.open(environment_path) as f:
                 data = f.read()
                 environment_md5 = md5(data).hexdigest()
+
+            # Get the run-local.sh
+            run_local_path = '{}/run-local.sh'.format(tale_id)
+            run_local_size = zip.getinfo(run_local_path).file_size
+            with zip.open(run_local_path) as f:
+                data = f.read()
+                run_local_md5 = md5(data).hexdigest()
+
+            # Get the fetch.txt
+            fetch_path = '{}/fetch.txt'.format(tale_id)
+            fetch_size = zip.getinfo(fetch_path).file_size
+            with zip.open(fetch_path) as f:
+                data = f.read()
+                fetch_md5 = md5(data).hexdigest()
 
             if job_manager:
                 job_manager.updateProgress(
@@ -135,15 +153,21 @@ class DataONEPublishProvider(PublishProvider):
             eml_pid = self._generate_pid(client)
             eml_doc = metadata.create_eml_doc(
                 eml_pid, manifest, user_id, manifest_size,
-                environment_size, license_text)
+                environment_size, run_local_size, fetch_size,
+                license_text)
 
             # Keep track of uploaded objects in case we need to rollback
             uploaded_pids = []
             try:
                 for fpath in files:
                     with zip.open(fpath) as f:
+
                         relpath = fpath.replace(tale_id, "..")
                         fname = os.path.basename(fpath)
+
+                        # Skip over the files we want to ignore
+                        if fname in ignore_files:
+                            continue
 
                         if job_manager:
                             job_manager.updateProgress(
@@ -160,6 +184,10 @@ class DataONEPublishProvider(PublishProvider):
                             size, hash = manifest_size, manifest_md5
                         elif fname == 'environment.json':
                             size, hash = environment_size, environment_md5
+                        elif fname == 'run-local.sh':
+                            size, hash = run_local_size, run_local_md5
+                        elif fname == 'fetch.txt':
+                            size, hash = fetch_size, fetch_md5
                         else:
                             size, hash = self._get_manifest_file_info(
                                 manifest, relpath)

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -31,15 +31,16 @@ class DataONEPublishProvider(PublishProvider):
         Close the connection between uploads otherwise some uploads will fail.
         """
         try:
-            return MemberNodeClient_2_0(dataone_node,
-                                        **{
-                                            "headers": {
-                                                "Authorization": "Bearer " + dataone_auth_token,
-                                                "Connection": "close"
-                                            },
-                                            "user_agent": "safari",
-                                        }
-                                        )
+            return MemberNodeClient_2_0(
+                dataone_node,
+                **{
+                    "headers": {
+                        "Authorization": "Bearer " + dataone_auth_token,
+                        "Connection": "close",
+                    },
+                    "user_agent": "safari",
+                }
+            )
         except InvalidToken as e:
             logging.warning(e)
             raise ValueError('Invalid DataONE JWT token. Please refresh the token.')

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -19,9 +19,6 @@ from d1_common.types.exceptions import DataONEException, InvalidToken
 from d1_common.env import D1_ENV_DICT
 
 from .metadata import DataONEMetadata
-
-from .constants import DataONELocations
-
 from gwvolman.lib.publish_provider import PublishProvider
 
 
@@ -35,14 +32,14 @@ class DataONEPublishProvider(PublishProvider):
         """
         try:
             return MemberNodeClient_2_0(dataone_node,
-               **{
-                    "headers": {
-                        "Authorization": "Bearer " + dataone_auth_token,
-                        "Connection": "close"
-                    },
-                    "user_agent": "safari",
-                }
-            )
+                                        **{
+                                            "headers": {
+                                                "Authorization": "Bearer " + dataone_auth_token,
+                                                "Connection": "close"
+                                            },
+                                            "user_agent": "safari",
+                                        }
+                                        )
         except InvalidToken as e:
             logging.warning(e)
             raise ValueError('Invalid DataONE JWT token. Please refresh the token.')


### PR DESCRIPTION
This PR fixes issue #83. This should be *fully* testable when we add support for file hierarchies on the DataONE side.

An example data package can be found [here](https://dev.nceas.ucsb.edu/view/urn:uuid:b45592e9-2c3e-4757-be23-af37f440c8f0)

The changes made here aren't that drastic. I use the bagit exported instead of native, which of course includes some additional files we don't want to put in the package (bagit.txt and friends)-you can see where I skip these in the code.

The two additional files follow the same paradigm as the environment and manifest, which amounts to
1. Creating new records in `constants.py`
2. Grabbing their file size and computing their md5
3. Sending the file size to the EML generation code
4. Adding the entries to the EML, using the info from steps 1 and 3

### To Test
1. Checkout the `md5_size_bag_additions` girder_wholetale branch
2. Checkout this branch
3. Create a Tale with files in the worksapce and external section
4. Publish to the development server
5. Make sure the fetch.txt and run-local.sh are present

Note that I think there's a bug in DataONE where multiple files with the same name are missing the `More Info` button. See [here](https://dev.nceas.ucsb.edu/view/urn:uuid:6c6ca9a1-426b-4a9e-972f-e5fdfa6b683a) and [here](https://dev.nceas.ucsb.edu/view/urn:uuid:dced13cf-f2a9-49d6-a087-a8df05aafbbc)