### PR TITLE
Don't build Image until Tale status is READY

### DIFF
--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -25,3 +25,8 @@ class InstanceStatus(object):
     LAUNCHING = 0
     RUNNING = 1
     ERROR = 2
+
+class TaleStatus(object):
+    PREPARING = 0
+    READY = 1
+    ERROR = 2

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -359,12 +359,15 @@ def build_tale_image(task, tale_id, force=False):
         message='Building image', total=BUILD_TALE_IMAGE_STEP_TOTAL,
         current=1, forceFlush=True)
 
+    tic = time.time()
     tale = task.girder_client.get('/tale/%s' % tale_id)
     while tale["status"] != TaleStatus.READY:
         time.sleep(2)
         tale = task.girder_client.get('/tale/{_id}'.format(**tale))
         if tale["status"] == TaleStatus.ERROR:
             raise ValueError("Cannot build image for a Tale in error state.")
+        if time.time() - tic > 5 * 60.0:
+            raise ValueError("Cannot build image. Tale preparing for more than 5 minutes.")
 
     last_build_time = -1
     try:

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -28,7 +28,7 @@ from .utils import \
 from .lib.dataone.publish import DataONEPublishProvider
 
 from .constants import GIRDER_API_URL, InstanceStatus, ENABLE_WORKSPACES, \
-    DEFAULT_USER, DEFAULT_GROUP, MOUNTPOINTS, REPO2DOCKER_VERSION
+    DEFAULT_USER, DEFAULT_GROUP, MOUNTPOINTS, REPO2DOCKER_VERSION, TaleStatus
 
 CREATE_VOLUME_STEP_TOTAL = 2
 LAUNCH_CONTAINER_STEP_TOTAL = 2
@@ -360,6 +360,11 @@ def build_tale_image(task, tale_id, force=False):
         current=1, forceFlush=True)
 
     tale = task.girder_client.get('/tale/%s' % tale_id)
+    while tale["status"] != TaleStatus.READY:
+        time.sleep(2)
+        tale = self.girder_client.get('/tale/{_id}'.format(**tale))
+        if tale["status"] == TaleStatus.ERROR:
+            raise ValueError("Cannot build image for a Tale in error state.")
 
     last_build_time = -1
     try:


### PR DESCRIPTION
This is a complementary PR to https://github.com/whole-tale/girder_wholetale/pull/350

1. Tale Image is only built if Tale's status is READY
2. During Tale import, Tale status is set to ERROR whenever the process raises an error.