### PR TITLE
Pass the base_url to dataset/register

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -568,8 +568,13 @@ def import_tale(self, lookup_kwargs, tale, spawn=True):
     self.job_manager.updateProgress(
         message='Registering the dataset in Whole Tale', total=total,
         current=2)
+    parameters = {'dataMap': json.dumps(dataMap)}
+    try:
+        parameters['base_url'] = lookup_kwargs.pop('base_url')
+    except KeyError:
+        pass
     self.girder_client.post(
-        '/dataset/register', parameters={'dataMap': json.dumps(dataMap)})
+        '/dataset/register', parameters=parameters)
 
     # Currently, we register resources in two different ways:
     #  1. DOIs (coming from Globus, Dataverse, DataONE, etc) create a root


### PR DESCRIPTION
This PR adds the base_url to the call to register the dataset.

Fixes https://github.com/whole-tale/girder_wholetale/issues/366
To Test
1. Deploy Locally
2. Try creating a Tale from the two URLs. One specifies the base_url, while the other one doesn't

`https://dashboard.local.wholetale.org/browse?uri=urn%3Auuid%3Adcf99f66-4a33-49c5-bd17-8f4332a15ebe&name=A+global+database+of+chlorophyll+and+water+chemistry+in+freshwater+lakes&api=https%3A%2F%2Fdev.nceas.ucsb.edu%2Fknb%2Fd1%2Fmn%2Fv2&environment=OpenRefine` 
and
`https://dashboard.local.wholetale.org/browse?uri=doi:10.18739/A2CN6Z03F&name=Dissolved nutrient concentrations, High Arctic Ocean, August-September 2018&environment=OpenRefine`

3. Make sure you see the data in the Tale