### PR TITLE
Check if the DataONE endpoint already has a v2

### DIFF
--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -106,8 +106,9 @@ class DataONEMetadata(object):
         :return: The ORE object
         :rtype: d1_common.resource_map.ResourceMap
         """
-
-        ore = ResourceMap(base_url=self.coordinating_node)
+        if self.coordinating_node.endswith("v2"):
+            ore_endpoint = self.coordinating_node[:-2]
+        ore = ResourceMap(base_url=ore_endpoint)
         ore.oreInitialize(pid)
         ore.addMetadataDocument(scimeta_pid)
         ore.addDataDocuments(sciobj_pid_list, scimeta_pid)

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -107,8 +107,9 @@ class DataONEMetadata(object):
         :rtype: d1_common.resource_map.ResourceMap
         """
         if self.coordinating_node.endswith("v2"):
-            ore_endpoint = self.coordinating_node[:-2]
-        ore = ResourceMap(base_url=ore_endpoint)
+            ore = ResourceMap(base_url=self.coordinating_node[:-2])
+        else:
+            ore = ResourceMap(base_url=self.coordinating_node)
         ore.oreInitialize(pid)
         ore.addMetadataDocument(scimeta_pid)
         ore.addDataDocuments(sciobj_pid_list, scimeta_pid)

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -41,7 +41,7 @@ class DataONEPublishProvider(PublishProvider):
         super().__init__(gc, tale_id, token, draft=draft, job_manager=job_manager)
         self.dataone_node = dataone_node
         self.dataone_auth_token = token["access_token"]
-        self.coordinating_node = "https://{}/cn/v2".format(token["resource_server"])
+        self.coordinating_node = "https://{}/cn/".format(token["resource_server"])
 
     def _connect(self):
         """
@@ -207,7 +207,7 @@ class DataONEPublishProvider(PublishProvider):
 
                         file_pid = self._generate_pid(client, scheme="UUID")
 
-                        mimeType = metadata.get_dataone_mimetype(
+                        mimeType = metadata.check_dataone_mimetype(
                             mimetypes.guess_type(fpath)[0]
                         )
 


### PR DESCRIPTION
Fixes #94 

#### Notes:

1. We now store the coordinating node without the `v2/` at the end.
2. The coordinating node client takes care of retrieving the supported formats

#### To Test:
1. Check this branch out
2. Publish a Tale to DataONE
3. Download the resource map at https://dev.nceas.ucsb.edu/knb/d1/mn/v2/object/<PACKAGE_PID>
4. Ensure that the RDF subject URIS have a single `v2`.

For example, the package [here](https://dev.nceas.ucsb.edu/view/doi:10.5072/FK2JS9RT3D) with resource map [here](https://dev.nceas.ucsb.edu/knb/d1/mn/v2/object/urn:uuid:2b084f1a-e498-46aa-8eb6-36b71a161b41) has valid subject URIS
`<rdf:Description rdf:about="https://cn-stage-2.test.dataone.org/cn/v2/resolve/urn:uuid:5adba71f-d2bb-417e-a63b-a982be1b127b">`

`  <rdf:Description rdf:about="https://cn-stage-2.test.dataone.org/cn/v2/resolve/urn:uuid:facff9ff-3324-47d2-9560-d453e13ccc25">`

As opposed to what's currently happening (note the extra v2)

`<rdf:Description rdf:about="https://cn-stage-2.test.dataone.org/cn/v2/v2/resolve/urn:uuid:5adba71f-d2bb-417e-a63b-a982be1b127b">`

`  <rdf:Description rdf:about="https://cn-stage-2.test.dataone.org/cn/v2/v2/resolve/urn:uuid:facff9ff-3324-47d2-9560-d453e13ccc25">`


5. Make sure that the format types for the files listed on the dataset landing page are sane/reasonable


#### To Do:

Fix the broken unit tests