### PR TITLE
Store the DOI as the Tale 'pid'

### DIFF
--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -309,7 +309,7 @@ class DataONEPublishProvider(PublishProvider):
 
                 self.tale["publishInfo"].append(
                     {
-                        "pid": res_pid,
+                        "pid": eml_pid,
                         "uri": package_url,
                         "date": datetime.datetime.utcnow().isoformat(),
                     }

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -296,7 +296,6 @@ class DataONEPublishProvider(PublishProvider):
                     file_object=io.BytesIO(res_map),
                     system_metadata=res_meta,
                 )
-
                 package_url = self._get_dataone_package_url(
                     self.coordinating_node, res_pid
                 )
@@ -310,6 +309,8 @@ class DataONEPublishProvider(PublishProvider):
                 self.tale["publishInfo"].append(
                     {
                         "pid": eml_pid,
+                        "repository": self.dataone_node,
+                        "repository_id": res_pid,
                         "uri": package_url,
                         "date": datetime.datetime.utcnow().isoformat(),
                     }


### PR DESCRIPTION
We are currently storing the resource map ID in the Tale's `pid` field. I think it makes more sense to save the doi here, which is what we do with Zenodo. We assign the doi to the EML document, which is why I use the `eml_pid` in the code change.

To Test
1. Check this branch out
2. Publish a Tale to Dev DataONE
3. Use the girder endpoint to look at the Tale's publishInfo
4. Make sure that you see a doi in the `pid` field.
5. Make sure that you see the member node in the `repository` field
6. Make sure that the ID in the `repository_id` field matches the resource map ID on the dataset landing page