### PR TITLE
[zenodo] use new version for subsequent Tale publications

### DIFF
--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -4,27 +4,47 @@
 import os
 import socket
 
-API_VERSION = '2.1'
+API_VERSION = "2.1"
 DEFAULT_USER = 1000
 DEFAULT_GROUP = 100
 ENABLE_WORKSPACES = True
-MOUNTPOINTS = ['data', 'home']
+MOUNTPOINTS = ["data", "home"]
 if ENABLE_WORKSPACES:
-    MOUNTPOINTS.append('workspace')
+    MOUNTPOINTS.append("workspace")
 
 try:
-    DEFAULT_GIRDER_API_URL = 'http://' + socket.gethostbyname('girder') + ':8080/api/v1'
+    DEFAULT_GIRDER_API_URL = "http://" + socket.gethostbyname("girder") + ":8080/api/v1"
 except socket.gaierror:
-    DEFAULT_GIRDER_API_URL = 'https://girder.dev.wholetale.org/api/v1'
-GIRDER_API_URL = os.environ.get('GIRDER_API_URL', DEFAULT_GIRDER_API_URL)
+    DEFAULT_GIRDER_API_URL = "https://girder.dev.wholetale.org/api/v1"
+GIRDER_API_URL = os.environ.get("GIRDER_API_URL", DEFAULT_GIRDER_API_URL)
 
 REPO2DOCKER_VERSION = 'wholetale/repo2docker_wholetale:latest'
+RUN_WT_BUTTON_IMG = (
+    "https://img.shields.io/badge/WholeTale-Run!-579ACA.svg?"
+    "logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABHNCSVQICAgIfAhki"
+    "AAAAAlwSFlzAAABDgAAAQ4B6Vk72QAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAOGSURBVDiNj"
+    "ZVdTJtVGMd/py+0IC0DNuhcwQKTC8OHY6WTZHGOxJiYmKGYLSQm6Mxu5jREix+7WGJ0xs+LSsbijdlQExSEscwroyNhY"
+    "7ghxi1AFDdaRusG0zG2VunH+z7elDpsS3wuz3me3/n/n5zzHMUaISImoBLYmFi6BswopSRTTVYGUBnw+o2wb0/w9mRxK"
+    "HITAulCEd+zYKI9ALvK6UC/61VaWCv+BbH3z3r7zbPhy6nVWG33s/DFc9Fygu2vqGU8mYE6qIfPevr3n8h0Ee2yYKzsJ"
+    "51OeUYohHXbzCzOEY4upgsfahsN9vL245qSjuQYllEXh72Hdt/IdDHAyWPcTW0i09+1gneiQJgM2s8WtFCk3Oci793Ez"
+    "einJ/rBdQLIjKtlPo4qVBEHL7F8Sv9E4csWx1tdP3kZvrP5bR2rWaNt3f8xcT1t4gbUUCxu/adiLNgS5VSas6UyDt4xn"
+    "/cUrm+kU8vblsFe8Rpo6OxhI7GEnbcZyMU1Tk0fA8P3rt3xRtnfMcsQAeASURMC+GZPQuhKyjTk1xa+DsJ69i2gWuXzr"
+    "HvcBf7DncxP3EOj3sDoajO6dl6rOb1AFwP/cYfYX+riCgTUBFcmirOtxQzfLUwCdvptHHy29MM/DBFXDeI6wb9o1N88/"
+    "0QO502vvOHqShyJ/ODt6dKgHITsEmXGIW5pcwuRZMJDRtzOfXjryk9HDz/C9sduYSiBtmaHQCT0ogZEQCHCZCbk3k444"
+    "+Tk/XvLdJMKaxkxBPvRBEnNzufLTl7WZyyAogSkc09PT2XOzs7eaL5KYo216DlWsmLh7m1dIuYxcZnY3MAtLnLyI7coW"
+    "BdActZedjis8xMz3HyxCna29tpbW2tzAJm6uvr52OxmP3E171Ab4qiZ559HhHhi4/ezKja5XItAP4spZSISF91dfWLk5"
+    "OTaZO/+vx4Zv9AbW0tVVVVXyqlZKVT73k8nmWz2Zy2wDAMDMNIu2c2m/F4PBHgQwATgFIqWFdXd9Dr9WK329dUc3fY7X"
+    "a8Xi81NTWvrkyeVcNBRI7oun5gaGiIgYEBxsbGEFk9+pRSuN1uWlpaaGpqQtO0I0qplzKeKiLtIhIWERkZGZGGhgZxuV"
+    "zicrnE7XbL6OioJCIsIimglHmYgDqA14CnBwcHHYFAAKUUpaWlNDc3B4F+4AOlVPB/Ae8CK6AC2JRYCgL+tb6AfwC+yH"
+    "oMI9RIjwAAAABJRU5ErkJggg=="
+)
 
 
 class InstanceStatus(object):
     LAUNCHING = 0
     RUNNING = 1
     ERROR = 2
+
 
 class TaleStatus(object):
     PREPARING = 0

--- a/gwvolman/lib/publish_provider.py
+++ b/gwvolman/lib/publish_provider.py
@@ -30,6 +30,7 @@ class PublishProvider(object):
             self.job_manager = NullManager()
 
         self.tale = self.gc.get("/tale/{}".format(tale_id))
+        assert self.tale["description"], "Cannot publish a Tale without a description."
         self.manifest = self.gc.get("/tale/{}/manifest".format(tale_id))
 
     @property

--- a/gwvolman/lib/publish_provider.py
+++ b/gwvolman/lib/publish_provider.py
@@ -9,6 +9,9 @@ class NullManager:
 
 
 class PublishProvider(object):
+    _published = None
+    _published_info_index = None
+
     def __init__(self, gc, tale_id, token, draft=False, job_manager=None):
         """
         Initialize PublishProvider
@@ -28,6 +31,25 @@ class PublishProvider(object):
 
         self.tale = self.gc.get("/tale/{}".format(tale_id))
         self.manifest = self.gc.get("/tale/{}/manifest".format(tale_id))
+
+    @property
+    def published(self):
+        if self._published is not None:
+            return self._published
+
+        for i, publish_info in enumerate(self.tale.get("publishInfo", [])):
+            if self.resource_server == publish_info.get("repository"):
+                self._published = True
+                self._published_info_index = i
+                break
+        else:
+            self._published = False
+        return self._published
+
+    @property
+    def publication_info(self):
+        if self.published:
+            return self.tale["publishInfo"][self._published_info_index]
 
     @property
     def access_token(self):

--- a/gwvolman/lib/zenodo.py
+++ b/gwvolman/lib/zenodo.py
@@ -11,6 +11,7 @@ from markdown import Markdown
 from lxml.html.clean import Cleaner
 
 from .publish_provider import PublishProvider
+from ..utils import DEPLOYMENT
 
 
 _ZENODO_ALLOWED_TAGS = {
@@ -289,8 +290,8 @@ class ZenodoPublishProvider(PublishProvider):
         # Add a self reference pointing to WT
         msg = (
             "Run this Tale on Whole Tale by clicking "
-            '<a href="https://data.wholetale.org/api/v1/integration/zenodo?{}">here</a>.'
-        ).format(urlencode({"doi": doi}))
+            '<a href="{girder_url}/api/v1/integration/zenodo?{query}">here</a>.'
+        ).format(girder_url=DEPLOYMENT.girder_url, query=urlencode({"doi": doi}))
         deposition["metadata"]["notes"] = msg
         try:
             deposition = self.update_deposition(deposition)

--- a/gwvolman/lib/zenodo.py
+++ b/gwvolman/lib/zenodo.py
@@ -248,6 +248,8 @@ class ZenodoPublishProvider(PublishProvider):
             "pid": doi,
             "uri": published_url,
             "date": datetime.datetime.utcnow().isoformat(),
+            "repository_id": str(deposition["id"]),
+            "repository": self.resource_server,
         }
         self.tale["publishInfo"].append(publish_info)
 

--- a/gwvolman/lib/zenodo.py
+++ b/gwvolman/lib/zenodo.py
@@ -5,7 +5,7 @@ import json
 import logging
 import requests
 import tempfile
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from markdown import Markdown
 from lxml.html.clean import Cleaner
@@ -31,6 +31,8 @@ _ZENODO_ALLOWED_TAGS = {
     "div",
     "strike",
 }
+
+_ACTION_CODES = {"publish": 202, "newversion": 201}
 
 
 class ZenodoPublishProvider(PublishProvider):
@@ -58,6 +60,7 @@ class ZenodoPublishProvider(PublishProvider):
 
     def deposit_tale(self, deposition):
         """Given a Zenodo deposition, upload tarball with a Tale."""
+
         self.update_progress(message="Uploading data to " + self.resource_server)
 
         stream = self.gc.sendRestRequest(
@@ -67,7 +70,7 @@ class ZenodoPublishProvider(PublishProvider):
             stream=True,
             jsonResp=False,
         )
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".zip") as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".zip") as tmp:
 
             # Write the zip file
             for chunk in stream.iter_content(chunk_size=65536):
@@ -163,15 +166,29 @@ class ZenodoPublishProvider(PublishProvider):
         logging.debug("[zenodo:create_deposition] deposition = {}".format(r.json()))
         return r.json()
 
-    def publish_deposition(self, deposition):
-        """Publish publish, I mean REALLY publish."""
+    def _zenodo_action(self, deposition, action):
         r = self.request(
-            "/api/deposit/depositions/{}/actions/publish".format(deposition["id"]),
+            "/api/deposit/depositions/{dep_id}/actions/{action}".format(
+                dep_id=deposition["id"], action=action
+            ),
             method="POST",
         )
-        assert r.status_code == 202
-        logging.debug("[zenodo:publish_deposition] deposition = {}".format(r.json()))
+        assert r.status_code == _ACTION_CODES[action]
+        logging.debug("[zenodo:_action_{}] deposition = {}".format(action, r.json()))
         return r.json()
+
+    def publish_deposition(self, deposition):
+        """Publish publish, I mean REALLY publish."""
+        return self._zenodo_action(deposition, "publish")
+
+    def create_new_version(self, deposition):
+        """Create a new version of an exisiting deposition."""
+        current_deposition = self._zenodo_action(deposition, "newversion")
+        # From zenodo docs:
+        # NOTE: The response body of this action is NOT the new version deposit,
+        # but the original resource. The new version deposition can be accessed
+        # through the "latest_draft" under "links" in the response body.
+        return self.retrieve_deposition(current_deposition["links"]["latest_draft"])
 
     def update_deposition(self, deposition):
         """Update deposition, assumes that metadata is changed."""
@@ -194,10 +211,71 @@ class ZenodoPublishProvider(PublishProvider):
         logging.debug("[zenodo:update_deposition] deposition = {}".format(r.json()))
         return r.json()
 
+    def retrieve_deposition(self, deposition_id):
+        """Get an existing deposition provided id or url."""
+        if deposition_id.startswith("http"):
+            url = urlparse(deposition_id).path
+        else:
+            url = "/api/deposit/depositions/{}".format(deposition_id)
+
+        r = self.request(
+            url, method="GET", headers={"Content-Type": "application/json"}
+        )
+
+        try:
+            r.raise_for_status()
+        except requests.HTTPError as exc:
+            msg = "Failed to get the deposition (id={}).".format(deposition_id)
+            msg += " Server returned: " + str(exc)
+            if r.status_code > 399 and r.status_code < 500:
+                msg += "\n" + json.dumps(r.json(), sort_keys=True, indent=4) + "\n"
+            logging.warning(msg)
+            raise ValueError(msg)
+        logging.debug("[zenodo:retrieve_deposition] deposition = {}".format(r.json()))
+        return r.json()
+
+    def remove_files(self, deposition):
+        for fileobj in deposition["files"]:
+            r = self.request(
+                "/api/deposit/depositions/{dep_id}/files/{file_id}".format(
+                    dep_id=deposition["id"], file_id=fileobj["id"]
+                ),
+                method="DELETE",
+            )
+
+            try:
+                r.raise_for_status()
+            except requests.HTTPError as exc:
+                msg = "Failed to remove file (id={}) from the deposition (id={}).".format(
+                    fileobj["id"], deposition["id"]
+                )
+                msg += " Server returned: " + str(exc)
+                if r.status_code > 399 and r.status_code < 500:
+                    msg += "\n" + json.dumps(r.json(), sort_keys=True, indent=4) + "\n"
+                logging.warning(msg)
+                raise ValueError(msg)
+
     def publish(self):
         """Publish the specified Tale to Zenodo."""
-        deposition = self.create_deposition()
+        if self.published:
+            old_deposition = self.retrieve_deposition(
+                self.publication_info["repository_id"]
+            )
+            deposition = self.create_new_version(old_deposition)
 
+            # NOTE: If Tale was already published the only way to "update" the
+            # payload is to delete the file and upload a new file.
+            self.remove_files(deposition)
+
+            deposition.update(self.get_tale_metadata())
+            deposition = self.update_deposition(deposition)
+
+            # TODO: Discard version if something goes wrong...
+        else:
+            deposition = self.create_deposition()
+        self.publish_version(deposition)
+
+    def publish_version(self, deposition):
         # Zenodo is nice and gives up preserved DOI at this point.
         # We should update the Tale before publishing so that
         # the manifest reflects that, shouldn't we?
@@ -239,7 +317,6 @@ class ZenodoPublishProvider(PublishProvider):
             doi = deposition["doi"]
             published_url = deposition["links"]["doi"]
 
-        logging.warning(deposition)
         self.update_progress(
             message="Your Tale has successfully been published to " + published_url
         )
@@ -251,7 +328,10 @@ class ZenodoPublishProvider(PublishProvider):
             "repository_id": str(deposition["id"]),
             "repository": self.resource_server,
         }
-        self.tale["publishInfo"].append(publish_info)
+        if self.published:
+            self.tale["publishInfo"][self._published_info_index].update(publish_info)
+        else:
+            self.tale["publishInfo"].append(publish_info)
 
         # Update the Tale with a reference to the published resource
         try:

--- a/gwvolman/tests/test_publish.py
+++ b/gwvolman/tests/test_publish.py
@@ -381,12 +381,137 @@ def mock_delete_deposition(url, request):
     )
 
 
+@httmock.urlmatch(
+    scheme="https",
+    netloc="^sandbox.zenodo.org$",
+    path="^/api/deposit/depositions/456$",
+    method="GET",
+)
+def mock_get_original_deposit_ok(url, request):
+    assert request.headers["Authorization"] == "Bearer zenodo_api_key"
+    return httmock.response(
+        status_code=200,
+        content={
+            "id": 456,
+            "doi": "10.345/6789",
+            "links": {"doi": "http://dx.doi.org/10.345/6789"},
+        },
+        headers={},
+        reason=None,
+        elapsed=5,
+        request=request,
+        stream=False,
+    )
+
+
+@httmock.urlmatch(
+    scheme="https",
+    netloc="^sandbox.zenodo.org$",
+    path="^/api/deposit/depositions/457$",
+    method="GET",
+)
+def mock_get_new_deposit_ok(url, request):
+    assert request.headers["Authorization"] == "Bearer zenodo_api_key"
+    return httmock.response(
+        status_code=200,
+        content={
+            "id": 457,
+            "doi": "10.345/6780",
+            "links": {"doi": "http://dx.doi.org/10.345/6780"},
+            "files": [
+                {
+                    "id": 1,
+                    "name": "already_published.zip",
+                    "filesize": 300,
+                    "checksum": "abcd",
+                }
+            ],
+        },
+        headers={},
+        reason=None,
+        elapsed=5,
+        request=request,
+        stream=False,
+    )
+
+
+@httmock.urlmatch(
+    scheme="https",
+    netloc="^sandbox.zenodo.org$",
+    path="^/api/deposit/depositions/457/files/1$",
+    method="DELETE",
+)
+def mock_delete_files_ok(url, request):
+    assert request.headers["Authorization"] == "Bearer zenodo_api_key"
+    return httmock.response(
+        status_code=204,
+        content=None,
+        headers={},
+        reason=None,
+        elapsed=5,
+        request=request,
+        stream=False,
+    )
+
+
+@httmock.urlmatch(
+    scheme="https",
+    netloc="^sandbox.zenodo.org$",
+    path="^/api/deposit/depositions/456/actions/newversion$",
+    method="POST",
+)
+def mock_new_version_ok(url, request):
+    assert request.headers["Authorization"] == "Bearer zenodo_api_key"
+    return httmock.response(
+        status_code=201,
+        content={
+            "id": 456,
+            "doi": "10.345/6789",
+            "links": {
+                "doi": "http://dx.doi.org/10.345/6789",
+                "latest_draft": "https://sandbox.zenodo.org/api/deposit/depositions/457",
+            },
+        },
+        headers={},
+        reason=None,
+        elapsed=5,
+        request=request,
+        stream=False,
+    )
+
+
+@httmock.urlmatch(
+    scheme="https",
+    netloc="^sandbox.zenodo.org$",
+    path="^/api/deposit/depositions/457$",
+    method="PUT",
+)
+def mock_update_newver_deposit_ok(url, request):
+    assert request.headers["Authorization"] == "Bearer zenodo_api_key"
+    req_data = json.loads(request.body)
+    return httmock.response(
+        status_code=200,
+        content={
+            "id": 457,
+            "links": {"self": "https://sandbox.zenodo.org/api/records/457"},
+            "metadata": req_data["metadata"],
+        },
+        headers={},
+        reason=None,
+        elapsed=5,
+        request=request,
+        stream=False,
+    )
+
+
 def mock_tale_update(path, json=None):
     assert path == "tale/" + TALE["_id"]
     assert len(json["publishInfo"]) == 1
     publish_info = json["publishInfo"][0]
     assert publish_info["pid"] == "10.123/123"
     assert publish_info["uri"] == "http://dx.doi.org/10.123/123"
+    assert publish_info["repository"] == "sandbox.zenodo.org"
+    assert publish_info["repository_id"] == "123"
 
 
 def mock_tale_update_dataone(path, json=None):
@@ -406,8 +531,20 @@ def mock_tale_update_draft(path, json=None):
 def mock_gc_get(path):
     if path in ("/tale/123", "tale/5cfd57fca18691e5d1feeda6"):
         return copy.deepcopy(TALE)
-    elif path == "/tale/123/manifest":
+    elif path.startswith("/tale") and path.endswith("/manifest"):
         return copy.deepcopy(MANIFEST)
+    elif path == "/tale/already_published":
+        tale = copy.deepcopy(TALE)
+        tale["_id"] = "already_published"
+        tale["publishInfo"] = [
+            {
+                "pid": "10.345/6789",
+                "uri": "http://dx.doi.org/10.345/6789",
+                "repository": "sandbox.zenodo.org",
+                "repository_id": "456",
+            }
+        ]
+        return tale
     else:
         raise RuntimeError
 
@@ -541,6 +678,20 @@ def test_zenodo_publish():
         with pytest.raises(ValueError) as error:
             publish("123", token, repository="sandbox.zenodo.org")
         assert error.match("Error updating Tale")
+
+    mock_gc.put = mock_tale_update
+    with httmock.HTTMock(
+        mock_get_original_deposit_ok,
+        mock_new_version_ok,
+        mock_get_new_deposit_ok,
+        mock_delete_files_ok,
+        mock_update_newver_deposit_ok,
+        mock_other_request,
+    ):
+        with mock.patch(
+            "gwvolman.tasks.ZenodoPublishProvider.publish_version", lambda x, y: None
+        ):
+            publish("already_published", token, repository="sandbox.zenodo.org")
 
 
 @pytest.mark.celery(result_backend="rpc")

--- a/gwvolman/tests/test_publish.py
+++ b/gwvolman/tests/test_publish.py
@@ -138,6 +138,8 @@ MANIFEST = {
 
 @httmock.all_requests
 def mock_other_request(url, request):
+    if request.url.startswith("http+docker://"):
+        return httmock.response(status_code=403)
     raise Exception("Unexpected url %s" % str(request.url))
 
 


### PR DESCRIPTION
Create a new version of a Zenodo deposition for a subsequent Tale publications.

### How to test

1. Create and publish a Tale to `sandbox.zenodo.org`
2. Change something (files or metadata) and publish again
3. Confirm that new version of existing deposition was created.