### PR TITLE
Add 'resource_server' to import link

### DIFF
--- a/gwvolman/lib/zenodo.py
+++ b/gwvolman/lib/zenodo.py
@@ -291,7 +291,10 @@ class ZenodoPublishProvider(PublishProvider):
         msg = (
             "Run this Tale on Whole Tale by clicking "
             '<a href="{girder_url}/api/v1/integration/zenodo?{query}">here</a>.'
-        ).format(girder_url=DEPLOYMENT.girder_url, query=urlencode({"doi": doi}))
+        ).format(
+            girder_url=DEPLOYMENT.girder_url,
+            query=urlencode({"doi": doi, "resource_server": self.resource_server}),
+        )
         deposition["metadata"]["notes"] = msg
         try:
             deposition = self.update_deposition(deposition)


### PR DESCRIPTION
Instead of trying to guess the resource server during import, we can actually set it as query parameter in the link we craft during publication... Makes the resulting url work outside Zenodo.

### How to test?
1. Publish a Tale
2. Copy a link from "Run this Tale on Whole Tale by clicking *here*." into separate browser window or embed it in hackmd.io markdown page and see if it works