### PR TITLE
Zenodo related ids

### DIFF
--- a/gwvolman/lib/zenodo.py
+++ b/gwvolman/lib/zenodo.py
@@ -32,7 +32,33 @@ _ZENODO_ALLOWED_TAGS = {
     "div",
     "strike",
 }
-
+_ZENODO_ACCEPTED_RELATIONS = {
+    "isCitedBy",
+    "cites",
+    "isSupplementTo",
+    "isSupplementedBy",
+    "isContinuedBy",
+    "continues",
+    "hasMetadata",
+    "isMetadataFor",
+    "isNewVersionOf",
+    "isPreviousVersionOf",
+    "isPartOf",
+    "hasPart",
+    "isReferencedBy",
+    "references",
+    "isDocumentedBy",
+    "documents",
+    "isCompiledBy",
+    "compiles",
+    "isVariantFormOf",
+    "isOrignialFormOf",
+    "isIdenticalTo",
+    "isReviewedBy",
+    "reviews",
+    "isDerivedFrom",
+    "isSourceOf"
+}
 _ACTION_CODES = {"publish": 202, "newversion": 201}
 
 
@@ -109,6 +135,22 @@ class ZenodoPublishProvider(PublishProvider):
         if self.manifest.get("schema:category"):
             keywords.add(self.manifest["schema:category"].title())
 
+        def first_letter_lower(s):
+            return s[:1].lower() + s[1:] if s else ""
+
+        related_identifiers = []
+        for related_id in self.tale.get("relatedIdentifiers", []):
+            relation = first_letter_lower(related_id["relation"])
+            if relation not in _ZENODO_ACCEPTED_RELATIONS:
+                continue
+            related_identifiers.append(
+                {"relation": relation, "identifier": related_id["identifier"]}
+            )
+        related_identifiers += [
+            {"relation": "cites", "identifier": ds["identifier"]}
+            for ds in self.manifest.get("Datasets", [])
+        ]
+
         return {
             "metadata": {
                 "upload_type": "publication",
@@ -130,10 +172,7 @@ class ZenodoPublishProvider(PublishProvider):
                 "access_right": "open",
                 "license": self.tale["licenseSPDX"].lower(),
                 "prereserve_doi": True,
-                "related_identifiers": [
-                    {"relation": "cites", "identifier": ds["identifier"]}
-                    for ds in self.manifest.get("Datasets", [])
-                ],
+                "related_identifiers": related_identifiers,
                 "references": [
                     citation for citation in self.tale.get("dataSetCitation", [])
                 ],

--- a/gwvolman/lib/zenodo.py
+++ b/gwvolman/lib/zenodo.py
@@ -322,6 +322,9 @@ class ZenodoPublishProvider(PublishProvider):
             message="Your Tale has successfully been published to " + published_url
         )
 
+        if doi and not doi.startswith("doi:"):
+            doi = "doi:{}".format(doi)
+
         publish_info = {
             "pid": doi,
             "uri": published_url,

--- a/gwvolman/tests/test_publish.py
+++ b/gwvolman/tests/test_publish.py
@@ -510,7 +510,7 @@ def mock_tale_update(path, json=None):
     assert path == "tale/" + TALE["_id"]
     assert len(json["publishInfo"]) == 1
     publish_info = json["publishInfo"][0]
-    assert publish_info["pid"] == "10.123/123"
+    assert publish_info["pid"] == "doi:10.123/123"
     assert publish_info["uri"] == "http://dx.doi.org/10.123/123"
     assert publish_info["repository"] == "sandbox.zenodo.org"
     assert publish_info["repository_id"] == "123"


### PR DESCRIPTION
This PR adds Tale's related identifiers to Zenodo's deposition in order to show them in their UI.

![zenodo](https://user-images.githubusercontent.com/352673/75178448-bc0e7480-56fd-11ea-811a-a953dbf44643.png)

Also fixes format of the doi in `publishInfo`, which is needed for https://github.com/whole-tale/girder_wholetale/pull/396

### How to test?
1. Create a Tale via AinWT from Dataverse or DataONE. Use `asTale=True` to get `IsDerivedFrom`, cause `cites` was already there.
2. Publish to Zenodo. Check if related identifier is there