### PR TITLE
Add dcterms:references relationship to DataONE resource maps

### DIFF
--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -98,6 +98,8 @@ class DataONEMetadata(object):
                     related_object = relation["DataCite:relatedIdentifier"]
                     if related_object["DataCite:relationType"] == "DataCite:Cites":
                         resource_map.add((eml_element, DCTERMS.references, Literal(related_object["@id"])))
+                    elif related_object["DataCite:relationType"] == "DataCite:IsDerivedFrom":
+                        resource_map.add((eml_element, DCTERMS.source, Literal(related_object["@id"])))
         except KeyError:
             pass
 

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -91,19 +91,23 @@ class DataONEMetadata(object):
         :param eml_pid: The pid of the EML document
         :return: The resource map
         """
+        eml_element = None
         try:
             eml_element = resource_map.getObjectByPid(eml_pid)
-            if eml_pid:
+        except IndexError:
+            logging.warning("Failed to find the pid {} in the resource map.".format(eml_pid))
+            return
+
+        if eml_element:
+            try:
                 for relation in manifest["DataCite:relatedIdentifiers"]:
                     related_object = relation["DataCite:relatedIdentifier"]
                     if related_object["DataCite:relationType"] == "DataCite:Cites":
                         resource_map.add((eml_element, DCTERMS.references, Literal(related_object["@id"])))
                     elif related_object["DataCite:relationType"] == "DataCite:IsDerivedFrom":
                         resource_map.add((eml_element, DCTERMS.source, Literal(related_object["@id"])))
-        except KeyError:
-            pass
-
-        return resource_map
+            except KeyError:
+                pass
 
 
     def get_access_policy(self):

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -5,7 +5,6 @@ from rdflib.term import Literal
 import re
 import xml.etree.cElementTree as ET
 
-
 try:
     from urllib.request import urlopen
 except ImportError:
@@ -86,6 +85,10 @@ class DataONEMetadata(object):
     def set_related_identifiers(self, manifest, resource_map, eml_pid):
         """
         Modifies a resource map to include cito:cites for any cited Tale entities
+
+        :param manifest: The Tale's manifest
+        :param resource_map: The resource map that will be submitted to DataONE
+        :param eml_pid: The pid of the EML document
         :return: The resource map
         """
         try:

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -289,6 +289,10 @@ class DataONEPublishProvider(PublishProvider):
                 # Create ORE
                 res_pid = self._generate_pid(client, scheme="UUID")
                 res_map = metadata.create_resource_map(res_pid, eml_pid, uploaded_pids)
+                # Update the resource map with citations
+                res_map = metadata.set_related_identifiers(manifest, res_map, eml_pid)
+                # Turn the resource map into readable bytes
+                res_map = res_map.serialize()
                 res_meta = metadata.generate_system_metadata(
                     pid=res_pid,
                     name=str(),

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -290,7 +290,7 @@ class DataONEPublishProvider(PublishProvider):
                 res_pid = self._generate_pid(client, scheme="UUID")
                 res_map = metadata.create_resource_map(res_pid, eml_pid, uploaded_pids)
                 # Update the resource map with citations
-                res_map = metadata.set_related_identifiers(manifest, res_map, eml_pid)
+                metadata.set_related_identifiers(manifest, res_map, eml_pid)
                 # Turn the resource map into readable bytes
                 res_map = res_map.serialize()
                 res_meta = metadata.generate_system_metadata(


### PR DESCRIPTION
We can include citation information in the DataONE ORE about datasets that the Tale has cited. This is a small code change that looks through the manifest for datacite citations, and then adds them to the ORE.

This will be ready to test when a small fix to the manifest is made. I'll remove this warning and assign reviewers when it's done.

To Test:
1. Deploy this branch
1. Use a Tale that has a citation link (you can update the Tale to have the snippet at the bottom)
1. Publish to DataONE Dev
1. Download the resource map
1. Search inside the resource map for `references` and make sure that you see the identifier from "relatedIdentifiers" referenced

To Download the resource map:
1. Visit the dataset landing page
1. ctrl+f 'Files in this dataset Package'
1. Copy the ID to the right of the first match
1. Paste it into the URL below and follow it
https://dev.nceas.ucsb.edu/knb/d1/mn/v2/object/PASTE_ID_HERE



 "relatedIdentifiers": [
    {
      "identifier": "urn:some_urn",
      "relation": "Cites"
    }
  ]