### PR TITLE
Publish the README as an extra file

### DIFF
--- a/gwvolman/lib/dataone/constants.py
+++ b/gwvolman/lib/dataone/constants.py
@@ -25,6 +25,7 @@ class ExtraFileNames:
     environment_file = 'environment.json'
     fetch_file = 'fetch.txt'
     run_local_file = 'run-local.sh'
+    readme_file = 'README.md'
 
 
 """
@@ -44,5 +45,7 @@ file_descriptions = {
         'before running the Tale',
     ExtraFileNames.run_local_file:
         'A bash script that downloads the neccessary external data and then runs '
-        'the Tale.'
+        'the Tale.',
+    ExtraFileNames.readme_file:
+        'A readme file that describes how to interact with this Tale.'
 }

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -356,6 +356,11 @@ class DataONEMetadata(object):
         self.add_object_record(dataset_elem, ExtraFileNames.fetch_file, description,
                                fetch_size, 'text/plain')
 
+        # Add README.md file
+        description = file_descriptions[ExtraFileNames.readme_file]
+        self.add_object_record(dataset_elem, ExtraFileNames.readme_file, description,
+                               fetch_size, 'text/plain')
+
         """
         Emulate the behavior of ElementTree.tostring in Python 3.6.0
         Write the contents to a stream and then return its content.

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -166,6 +166,13 @@ class DataONEPublishProvider(PublishProvider):
                 data = f.read()
                 fetch_md5 = md5(data).hexdigest()
 
+            # Get the README.md
+            readme_path = "{}/README.md".format(self.tale["_id"])
+            readme_size = zip.getinfo(readme_path).file_size
+            with zip.open(readme_path) as f:
+                data = f.read()
+                readme_md5 = md5(data).hexdigest()
+
             self.job_manager.updateProgress(
                 message="Creating EML document from manifest",
                 total=100,
@@ -197,7 +204,6 @@ class DataONEPublishProvider(PublishProvider):
                         # Skip over the files we want to ignore
                         if fname in ignore_files:
                             continue
-
                         self.job_manager.updateProgress(
                             message="Uploading file {}".format(fname),
                             total=100,
@@ -219,6 +225,8 @@ class DataONEPublishProvider(PublishProvider):
                             size, hash = run_local_size, run_local_md5
                         elif fname == "fetch.txt":
                             size, hash = fetch_size, fetch_md5
+                        elif fname == 'README.md':
+                            size, hash = readme_size, readme_md5
                         else:
                             size, hash = self._get_manifest_file_info(manifest, relpath)
 

--- a/gwvolman/tests/test_publish.py
+++ b/gwvolman/tests/test_publish.py
@@ -88,7 +88,6 @@ MANIFEST = {
         {"uri": "../workspace/requirements.txt"},
         {"uri": "../workspace/wt_quickstart.ipynb"},
         {"uri": "../workspace/apt.txt"},
-        {"uri": "../workspace/README.md"},
         {
             "bundledAs": {"filename": "usco2005.xls", "folder": "../data/"},
             "schema:isPartOf": "doi:10.5065/D6862DM8",
@@ -99,7 +98,6 @@ MANIFEST = {
             ),
         },
         {"schema:license": "CC-BY-4.0", "uri": "../LICENSE"},
-        {"@type": "schema:HowTo", "uri": "../README.md"},
     ],
     "createdBy": {
         "@id": "willis8@illinois.edu",


### PR DESCRIPTION
This PR is a compliment to https://github.com/whole-tale/girder_wholetale/pull/401

The code changes are pretty standard. With the changes in the linked issue above, a published package will miss the README file. Since it's no longer in the manifest, we treat it like the fetch, run-local, environment, and manifest.json file.

For testing, refer to the linked issue.