### PR TITLE
Avoid hardcoding docker root dir

### DIFF
--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -238,8 +238,8 @@ def _launch_container(volumeName, nodeId, container_config, tale_id='', instance
     #                        target=container_config.target_mount)
     # ]
 
-    # FIXME: get mountPoint
-    source_mount = '/var/lib/docker/volumes/{}/_data'.format(volumeName)
+    volume = cli.volumes.get(volumeName)
+    source_mount = volume.attrs["Mountpoint"]
     mounts = []
     for path in MOUNTPOINTS:
         source = os.path.join(source_mount, path)


### PR DESCRIPTION
Dedicated to all those who use a custom volume in a non-standard place for docker root directory.

### How to test?
1. Deploy
1. Register Ligo
1. Run LIGO and check if filesystems are mounted.