### PR TITLE
Update dataone tales

### DIFF
--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -454,7 +454,7 @@ class DataONEMetadata(object):
         return sys_meta
 
     @staticmethod
-    def _get_directory(self, user_id: str) -> str:
+    def _get_directory(user_id: str) -> str:
         """
         Returns the directory that should be used in the EML
 

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -113,7 +113,9 @@ class DataONEMetadata(object):
                     related_object = relation["DataCite:relatedIdentifier"]
                     if related_object["DataCite:relationType"] == "DataCite:Cites":
                         self.resource_map.add((eml_element, DCTERMS.references, URIRef(related_object["@id"])))
+                        added_record = True
                     elif related_object["DataCite:relationType"] == "DataCite:IsDerivedFrom":
+                        added_record = True
                         self.resource_map.add((eml_element,
                                                datacite_namespace.IsDerivedFrom, URIRef(related_object["@id"])))
                 if tale['copyOfTale']:

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -122,7 +122,9 @@ class DataONEMetadata(object):
                     try:
                         parent_tale = gc.get("tale/{}".format(tale['copyOfTale']))
                         old_publish = next(
-                            item for item in parent_tale['publishInfo'] if item['repository'] == member_node)
+                            (item for item in parent_tale['publishInfo'] if item['repository'] == member_node),
+                            None
+                        )
                         if old_publish:
                             self.resource_map.add((eml_element,
                                                    datacite_namespace.IsDerivedFrom, URIRef(old_publish['pid'])))

--- a/gwvolman/lib/dataone/metadata.py
+++ b/gwvolman/lib/dataone/metadata.py
@@ -6,7 +6,9 @@ from rdflib import Namespace
 from rdflib.term import URIRef
 from rdflib.term import Literal
 import re
+from typing import List
 import xml.etree.cElementTree as ET
+
 
 try:
     from urllib.request import urlopen
@@ -114,7 +116,6 @@ class DataONEMetadata(object):
             except KeyError:
                 pass
 
-
     def get_access_policy(self):
         """
         Returns or creates the access policy for the system metadata.
@@ -142,17 +143,16 @@ class DataONEMetadata(object):
 
         return self.access_policy
 
-    def create_resource_map(self, pid, scimeta_pid, sciobj_pid_list):
+    def create_resource_map(self, pid: str, scimeta_pid: str, sciobj_pid_list: List):
         """
         Create a simple resource map with one science metadata document and any
         number of science data objects.
         This method differs from d1_common.resource_map.createSimpleResourceMap
         by allowing you to specify the coordinating node that the objects
         can be found on.
+        :param pid: The resource map's pid
         :param scimeta_pid: PID of the metadata document
-        :param sciobj_pid_list: PID of the upload object
-        :type scimeta_pid: str
-        :type sciobj_pid_list: list
+        :param sciobj_pid_list: List of pids of data objects being uploaded
         """
         ore: ResourceMap = ResourceMap(base_url=self.coordinating_node)
         ore.initialize(pid)
@@ -254,6 +254,7 @@ class DataONEMetadata(object):
         :param root: The parent XML element
         :param first_name: The user's first name
         :param last_name: The user's last name
+        :param user_id: The user's ORCID
         :type root: xml.etree.ElementTree.Element
         :type first_name: str
         :type last_name: str
@@ -363,8 +364,8 @@ class DataONEMetadata(object):
             if 'bundledAs' not in item:
                 name = os.path.basename(item['uri'])
                 size = item['size']
-                mimeType = self.check_dataone_mimetype(item['mimeType'])
-                self.add_object_record(dataset_elem, name, '', size, mimeType)
+                mime_type = self.check_dataone_mimetype(item['mimeType'])
+                self.add_object_record(dataset_elem, name, '', size, mime_type)
 
         # Add the manifest itself
         name = ExtraFileNames.manifest_file

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -288,9 +288,10 @@ class DataONEPublishProvider(PublishProvider):
 
                 # Create ORE
                 res_pid = self._generate_pid(client, scheme="UUID")
-                res_map = metadata.create_resource_map(res_pid, eml_pid, uploaded_pids)
+                metadata.create_resource_map(res_pid, eml_pid, uploaded_pids)
+                metadata.set_related_identifiers(manifest, eml_pid)
+                res_map = metadata.resource_map.serialize()
                 # Update the resource map with citations
-                metadata.set_related_identifiers(manifest, res_map, eml_pid)
                 # Turn the resource map into readable bytes
                 res_map = res_map.serialize()
                 res_meta = metadata.generate_system_metadata(

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -16,8 +16,9 @@ except ImportError:
     from urllib.parse import urlparse
 
 from d1_client.mnclient_2_0 import MemberNodeClient_2_0
-from d1_common.types.exceptions import DataONEException, InvalidToken
+from d1_common.types.exceptions import DataONEException, InvalidToken, NotFound
 from d1_common.types.generated.dataoneTypes_v2_0 import SystemMetadata
+from d1_common.types import dataoneTypes
 from d1_common.env import D1_ENV_DICT
 
 from .metadata import DataONEMetadata
@@ -53,7 +54,7 @@ class DataONEPublishProvider(PublishProvider):
         Close the connection between uploads otherwise some uploads will fail.
         """
         try:
-            return MemberNodeClient_2_0(
+            self.client = MemberNodeClient_2_0(
                 self.dataone_node,
                 **{
                     "headers": {
@@ -247,28 +248,30 @@ class DataONEPublishProvider(PublishProvider):
                 )
                 step += 1
 
-                # Upload the EML document and system metadata
-                eml_meta = metadata.generate_system_metadata(
-                    pid=eml_pid,
-                    name="metadata.xml",
-                    format_id="eml://ecoinformatics.org/eml-2.1.1",
-                    size=len(eml_doc),
-                    md5=md5(eml_doc).hexdigest(),
-                    rights_holder=user_id,
-                )
+                try:
+                    last_eml_pid = self.tale['publishInfo']['DataONE']['pid']
+                    previous_sysmeta = self.client.getSystemMetadata(last_eml_pid)
+                    # Use the system metadata from the previous EML document
+                    new_sysmeta = self.update_sysmeta(previous_sysmeta, eml_doc, eml_pid)
+                    self._obsolete_object(last_eml_pid, eml_pid, eml_doc, new_sysmeta)
 
-                # This fails with:
-                #   The supplied system metadata is invalid. The obsoletes
-                #   field cannot have a value when creating entries.
-                # if tale['publishInfo']:
-                #    old_pid = tale['publishInfo'][-1]['pid']
-                #    eml_meta.obsoletes = old_pid
+                except (IndexError, NotFound, Exception) as e:
+                    # Then this hasn't been published before and could not be updated
+                    # The blanket Exception is to catch any sort of potential crashing from
+                    # a failed dataone request
+                    # Publish an initial version
+                    eml_meta = metadata.generate_system_metadata(
+                        pid=eml_pid, name='metadata.xml',
+                        format_id='eml://ecoinformatics.org/eml-2.1.1',
+                        size=len(eml_doc),
+                        md5=md5(eml_doc).hexdigest(),
+                        rights_holder=user_id)
+                    self._upload_file(
+                        pid=eml_pid,
+                        file_object=io.BytesIO(eml_doc),
+                        system_metadata=eml_meta,
+                    )
 
-                self._upload_file(
-                    pid=eml_pid,
-                    file_object=io.BytesIO(eml_doc),
-                    system_metadata=eml_meta,
-                )
 
                 uploaded_pids.append(eml_pid)
 
@@ -286,11 +289,11 @@ class DataONEPublishProvider(PublishProvider):
                 # Create ORE
                 res_pid = self._generate_pid(scheme="UUID")
                 metadata.create_resource_map(res_pid, eml_pid, uploaded_pids)
-                metadata.set_related_identifiers(manifest, eml_pid)
+                metadata.set_related_identifiers(manifest, eml_pid, self.tale,
+                                                 self.dataone_node,  self.gc)
                 res_map = metadata.resource_map.serialize()
                 # Update the resource map with citations
                 # Turn the resource map into readable bytes
-                res_map = res_map.serialize()
                 res_meta = metadata.generate_system_metadata(
                     pid=res_pid,
                     name=str(),
@@ -328,20 +331,12 @@ class DataONEPublishProvider(PublishProvider):
                     self.gc.put("tale/{}".format(self.tale["_id"]), json=self.tale)
                 except Exception as e:
                     logging.warning("Error updating Tale {}".format(str(e)))
-                    raise ValueError("Error updating Tale {}".format(str(e)))
+                    raise ValueError("There was an error while updating the Tale.\n{}".format(e))
 
             except Exception as e:
-                logging.warning("Error. Should rollback... {}".format(str(e)))
-                # Getting permission denied on delete
-                # for pid in uploaded_pids:
-                #    try:
-                #        logging.info("Deleting pid {} if I could...".format(
-                #            pid))
-                #        client.delete(pid)
-                #    except Exception as e:
-                #        logging.warning('Error deleting pid {}: {}'.format(
-                #            pid, str(e)))
-                raise
+                logging.warning("Error while publishing Tale{}".format(e))
+                raise ValueError("There was a fatal error while publishing the Tale. Please "
+                                 "contact the support team.\n{}".format(e))
 
     @staticmethod
     def _get_manifest_file_info(manifest, relpath):
@@ -451,3 +446,46 @@ class DataONEPublishProvider(PublishProvider):
         except DataONEException as e:
             logging.warning(e)
             raise ValueError("Failed to generate identifier.")
+
+    def _obsolete_object(self, old_pid, new_pid, new_object, sysmeta):
+        """
+        Obsoletes an object with a new one. The coordinating node will handle modifying the
+        system metadata with the appropriate obsoletion flags. It's most likely that this should
+        only be called with a new resource map and EML document.
+        :param old_pid: The pid of the existing object
+        :param new_pid: The new package resource map pid
+        :param new_object: The new object that is replacing the existing one
+        :param sysmeta: The new object's system metadata document
+        :return: None
+        """
+        try:
+            self.client.update(old_pid, io.BytesIO(new_object), new_pid, sysmeta)
+
+        except DataONEException as e:
+            logging.error('Error obsoleting package {} with {}. {}'.format(old_pid, new_pid, e))
+            raise ValueError('Failed to obsolete the previous version of the Tale. {}'.format(e))
+
+    @staticmethod
+    def update_sysmeta(sysmeta: SystemMetadata, bytes_to_upload: Union[str, bytes], new_pid):
+        """
+        Updates a system metadata document to describe a different object. The idea is that the
+        DataONE server will set various fields on the system metadata (AuthortativeMemberNode, for example)
+        and when obsoleting an object-those fields are desired. Some fields like the checksum and file size will
+        be different and need to be updated, which is what this method is for.
+        :param sysmeta: The system metadata document
+        :param bytes_to_upload: The bytes that are being uploaded to DataONE
+        :param new_pid: The pid of the object representing the bytes
+        """
+        if not isinstance(bytes_to_upload, bytes):
+            if isinstance(bytes_to_upload, str):
+                bytes_to_upload = bytes_to_upload.encode("utf-8")
+            else:
+                raise ValueError('Unable to convert the data object with pid {} to bytes'.format(new_pid))
+        size = len(bytes_to_upload)
+        checksum = md5(bytes_to_upload).hexdigest()
+        sysmeta.identifier = str(new_pid)
+        sysmeta.size = size
+        sysmeta.checksum = dataoneTypes.checksum(str(checksum))
+        sysmeta.checksum.algorithm = 'MD5'
+        sysmeta.obsoletes = None
+        return sysmeta

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -123,50 +123,50 @@ class DataONEPublishProvider(PublishProvider):
             tmp.seek(0)
 
             # Read the zipfile
-            zip = zipfile.ZipFile(tmp, "r")
-            files = zip.namelist()
+            zip_file = zipfile.ZipFile(tmp, "r")
+            files = zip_file.namelist()
 
             # Now we know the number of steps for progress
             steps = len(files) + 5
 
             # Get the manifest
             manifest_path = "{}/metadata/manifest.json".format(self.tale["_id"])
-            manifest_size = zip.getinfo(manifest_path).file_size
-            with zip.open(manifest_path) as f:
+            manifest_size = zip_file.getinfo(manifest_path).file_size
+            with zip_file.open(manifest_path) as f:
                 data = f.read()
                 manifest_md5 = md5(data).hexdigest()
                 manifest = json.loads(data.decode("utf-8"))
 
             # Read the license text
             license_path = "{}/data/LICENSE".format(self.tale["_id"])
-            with zip.open(license_path) as f:
+            with zip_file.open(license_path) as f:
                 license_text = str(f.read().decode("utf-8"))
 
             # Get the environment
             environment_path = "{}/metadata/environment.json".format(self.tale["_id"])
-            environment_size = zip.getinfo(environment_path).file_size
-            with zip.open(environment_path) as f:
+            environment_size = zip_file.getinfo(environment_path).file_size
+            with zip_file.open(environment_path) as f:
                 data = f.read()
                 environment_md5 = md5(data).hexdigest()
 
             # Get the run-local.sh
             run_local_path = "{}/run-local.sh".format(self.tale["_id"])
-            run_local_size = zip.getinfo(run_local_path).file_size
-            with zip.open(run_local_path) as f:
+            run_local_size = zip_file.getinfo(run_local_path).file_size
+            with zip_file.open(run_local_path) as f:
                 data = f.read()
                 run_local_md5 = md5(data).hexdigest()
 
             # Get the fetch.txt
             fetch_path = "{}/fetch.txt".format(self.tale["_id"])
-            fetch_size = zip.getinfo(fetch_path).file_size
-            with zip.open(fetch_path) as f:
+            fetch_size = zip_file.getinfo(fetch_path).file_size
+            with zip_file.open(fetch_path) as f:
                 data = f.read()
                 fetch_md5 = md5(data).hexdigest()
 
             # Get the README.md
             readme_path = "{}/README.md".format(self.tale["_id"])
-            readme_size = zip.getinfo(readme_path).file_size
-            with zip.open(readme_path) as f:
+            readme_size = zip_file.getinfo(readme_path).file_size
+            with zip_file.open(readme_path) as f:
                 data = f.read()
                 readme_md5 = md5(data).hexdigest()
 
@@ -194,7 +194,7 @@ class DataONEPublishProvider(PublishProvider):
             uploaded_pids = []
             try:
                 for fpath in files:
-                    with zip.open(fpath) as f:
+                    with zip_file.open(fpath) as f:
                         relpath = fpath.replace(self.tale["_id"], "..")
                         fname = os.path.basename(fpath)
 


### PR DESCRIPTION
Fixes issue #107. This is a rewrite of a much uglier PR (#111 ). This PR does _not_ include the refactored unit tests, but _does_ give a little more clarity into the Tale updating changes.

The first two commits just pull things into a few classes to make things easier down the road. The next few fix up a few pep issues. The last commit fixed this issue where one except statement was swallowing an exception from a nested try/catch. I flattened the try/catch blocks and things seem to be working fine.

### Reviewer Note

#115 should be merged after this PR is merged.

### Updating

A Tale is 'updated' when it's published a second time. If a Tale is published to DataONE, and then a copy is made and 
 subsequently published the `datacite:IsDerivedFrom` relation pointing to the first Tale's doi is added to the resource map of the newly published object (see example below for clarity). 

When a Tale is published to DataONE two times, the previous system metadata for the EML is retrieved. A new system metadata document is made from it, but with values such for md5 and size updated. This system metadata document is uploaded with the new EML document, and effectively signals DataONE to obsolete the package.

## Testing

1. Create a Tale
2. Publish it to DataONE
3. View the landing page for that Tale in a new tab (don't close the tab!)
4. Publish again
5. Refresh the URL from step 3, you should see a notification that there is an updated version available
_

1. Create a Tale
2. Publish it to DataONE
3. Make the Tale public
4. Sign out and sign in under a new account
5. Copy the Tale from step 1
6. Publish it to DataONE
7. Copy the ID of the resource map (the uuid in the picture below)
8. Visit https://dev.nceas.ucsb.edu/knb/d1/mn/v2/object/<RESOURCE_MAP_ID>
9. Search for "datacite"
10. Check that it references the copied Tale's doi


Example:

I published a Tale [here](https://dev.nceas.ucsb.edu/view/urn:uuid:12539245-06fc-482e-bec4-da2db24490c2), copied it and republished [here](https://dev.nceas.ucsb.edu/view/urn:uuid:e3cb4097-4182-4615-a8c4-74c91cb8a928). In the _new_ resource map found [here]( https://dev.nceas.ucsb.edu/knb/d1/mn/v2/object/urn:uuid:e3cb4097-4182-4615-a8c4-74c91cb8a928), you can see that the datacite:IsDerivedFrom points to the DOI of the first package.

