### PR TITLE
Set delay_upload to 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN sed \
 # https://github.com/whole-tale/wt_home_dirs/issues/18
 RUN echo "use_locks 0" >> /etc/davfs2/davfs2.conf && \
   echo "backup_dir .lost+found" >> /etc/davfs2/davfs2.conf && \
+  echo "delay_upload 0" >> /etc/davfs2/davfs2.conf && \
   echo "gui_optimize 1" >> /etc/davfs2/davfs2.conf
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN sed \
 # https://github.com/whole-tale/wt_home_dirs/issues/18
 RUN echo "use_locks 0" >> /etc/davfs2/davfs2.conf && \
   echo "backup_dir .lost+found" >> /etc/davfs2/davfs2.conf && \
-  echo "delay_upload 0" >> /etc/davfs2/davfs2.conf && \
+  echo "delay_upload 1" >> /etc/davfs2/davfs2.conf && \
   echo "gui_optimize 1" >> /etc/davfs2/davfs2.conf
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
This PR changes the value of `delay_upload` in `davfs2.conf` from the default 10 seconds to 0 seconds.

**Problem**:
When two users are editing the workspace for a shared tale, workspace changes from one user are not propagated to the other for 10 seconds. Also, in the past when rebuilding a tale the user had to wait 10 seconds for changes to be recognized by the system. This is because the davsfs2.conf `delay_upload` setting defaults to 10 seconds.


From the docs:
> delay_upload: When a file that has been changed is closed, mount.davfs will wait that many seconds before it will upload it to the server. This will avoid uploading of temporary files that will be removed immediately after closing. If you need the files to appear on the server immediately after closing, set this option to 0. Default: 10


**Test steps**:
1. Start a shared tale as both user1 and user2
1. Created, edit, or remove a file as one user, wait for changes to appear for second user

Changes should appear in 1-2 seconds, not the usual 10.