### PR TITLE
Published dataSet must be expanded

### DIFF
--- a/gwvolman/lib/publish_provider.py
+++ b/gwvolman/lib/publish_provider.py
@@ -31,7 +31,9 @@ class PublishProvider(object):
 
         self.tale = self.gc.get("/tale/{}".format(tale_id))
         assert self.tale["description"], "Cannot publish a Tale without a description."
-        self.manifest = self.gc.get("/tale/{}/manifest".format(tale_id))
+        self.manifest = self.gc.get(
+            "/tale/{}/manifest".format(tale_id), parameters={"expandFolders": True}
+        )
 
     @property
     def published(self):

--- a/gwvolman/tests/test_publish.py
+++ b/gwvolman/tests/test_publish.py
@@ -541,10 +541,12 @@ def mock_tale_update_draft(path, json=None):
     assert publish_info["uri"] == "https://sandbox.zenodo.org/api/records/123"
 
 
-def mock_gc_get(path):
+def mock_gc_get(path, parameters=None):
     if path in ("/tale/123", "tale/5cfd57fca18691e5d1feeda6"):
         return copy.deepcopy(TALE)
     elif path.startswith("/tale") and path.endswith("/manifest"):
+        assert "expandFolders" in parameters
+        assert parameters["expandFolders"] == True
         return copy.deepcopy(MANIFEST)
     elif path == "/tale/already_published":
         tale = copy.deepcopy(TALE)


### PR DESCRIPTION
This came up during discussion related to https://github.com/whole-tale/girder_wholetale/pull/440. In a gist: when we export Tales out of the system, we need to make sure that ephemeral references (like DV subfolders) are expanded into actual physical objects.