### PR TITLE
Migrate to traefik v2 and add support for forward auth

### DIFF
--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -21,7 +21,7 @@ DOCKER_URL = os.environ.get("DOCKER_URL", "unix://var/run/docker.sock")
 HOSTDIR = os.environ.get("HOSTDIR", "/host")
 MAX_FILE_SIZE = os.environ.get("MAX_FILE_SIZE", 200)
 DOMAIN = os.environ.get('DOMAIN', 'dev.wholetale.org')
-TRAEFIK_ENTRYPOINT = os.environ.get("TRAEFIK_ENTRYPOINT", "http")
+TRAEFIK_ENTRYPOINT = os.environ.get("TRAEFIK_ENTRYPOINT", "websecure")
 REGISTRY_USER = os.environ.get('REGISTRY_USER', 'fido')
 REGISTRY_PASS = os.environ.get('REGISTRY_PASS')
 MOUNTS = {}
@@ -110,8 +110,11 @@ class Deployment(object):
         """
         try:
             service = self.docker_client.services.get(service_name)
-            rule = service.attrs['Spec']['Labels']['traefik.frontend.rule']
-            return 'https://' + rule.split(':')[-1].split(',')[0].strip()
+            ns = service.attrs['Spec']['Labels']['com.docker.stack.namespace']
+            router = service_name.replace('%s_' % ns,  '')
+            rule = service.attrs['Spec']['Labels']['traefik.http.routers.%s.rule' % router]
+            host =  re.search(r'Host\(`(.+)`\)', rule).group(1)
+            return 'https://' + host
         except docker.errors.APIError:
             return '{}://{}.{}'.format(TRAEFIK_ENTRYPOINT, service_name[3:], DOMAIN)
 
@@ -272,13 +275,14 @@ def _launch_container(volumeName, nodeId, container_config, tale_id='', instance
         container_config.image,
         command=rendered_command,
         labels={
-            'traefik.port': str(container_config.container_port),
+            'traefik.http.services.%s.loadbalancer.server.port' % host: str(container_config.container_port),
             'traefik.enable': 'true',
-            'traefik.frontend.rule': 'Host:{}.{}'.format(host, DOMAIN),
-            'traefik.frontend.headers.contentSecurityPolicy': csp,
+            'traefik.http.routers.%s.rule' % host: 'Host(`{}.{}`)'.format(host, DOMAIN),
+            'traefik.http.routers.%s.entrypoints' % host: TRAEFIK_ENTRYPOINT,
+            'traefik.http.middlewares.%s.headers.contentSecurityPolicy' % host: csp,
+            'traefik.http.services.%s.loadbalancer.passhostheader' % host: 'true',
+            'traefik.http.services.%s.loadbalancer.server.port' % host: str(container_config.container_port),
             'traefik.docker.network': DEPLOYMENT.traefik_network,
-            'traefik.frontend.passHostHeader': 'true',
-            'traefik.frontend.entryPoints': TRAEFIK_ENTRYPOINT,
             'wholetale.instanceId': instance_id,
             'wholetale.taleId': tale_id,
         },


### PR DESCRIPTION
See https://github.com/whole-tale/deploy-dev/pull/44 for test and https://github.com/whole-tale/whole-tale/issues/94 for problem description.

This PR changes annotations to Traefik v2 format.

