### PR TITLE
Always rebuild image if tale's imageId has changed

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -381,10 +381,14 @@ def build_tale_image(task, tale_id, force=False):
 
     logging.info('Last build time {}'.format(last_build_time))
 
-    # TODO: Move this check to the model?
-    # Only rebuild if files have changed since last build
-    if last_build_time > 0:
+    image_changed = tale["imageId"] != tale["imageInfo"].get("imageId")
+    if image_changed:
+        logging.info("Base image has changed. Forcing rebuild.")
+        force = True
 
+    # TODO: Move this check to the model?
+    # Only rebuild if files have changed since last build or base image was changed
+    if last_build_time > 0:
         workspace_folder = task.girder_client.get('/folder/{workspaceId}'.format(**tale))
         workspace_mtime = int(parse(workspace_folder['updated']).strftime('%s'))
 


### PR DESCRIPTION
Have you ever been annoyed by the fact that changing the base Image and hitting "Rebuild Tale" results in noop and a lousy message "Workspace not modified. Skipping build"? If so, this PR is for you!

### How to test?
1. Needs https://github.com/whole-tale/girder_wholetale/pull/472
2. Create a Tale with RStudio. Launch it.
3. After instance is up, go to Metadata page and change image.
4. Using Tale Action menu click "Rebuild Tale"
5. Confirm that image is being built even if you didn't touch the workspace.