### PR TITLE
Add launch timeout and failure handling

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -187,19 +187,20 @@ def launch_container(self, payload):
         f"on node: {payload['nodeId']}"
     )
 
+    # wait until task is started
     tic = time.time()
     timeout = 300.0
+    started = False
 
-    # wait until task is started
     print("Waiting for the environment to be accessible...")
     while time.time() - tic < timeout:
         try:
             status = service.tasks()[0]['Status']
-            error = status['State'] in {"failed", "rejected"}
 
-            if error:
+            if status['State'] in {"failed", "rejected"}:
                 raise ValueError("Failed to start environment: %s" % status['Err'])
             elif status['State'] == "running":
+                started = True
                 break
 
         except IndexError:

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -295,7 +295,8 @@ def _launch_container(volumeName, nodeId, container_config, tale_id='', instance
         mounts=mounts,
         endpoint_spec=endpoint_spec,
         constraints=['node.id == {}'.format(nodeId)],
-        resources=docker.types.Resources(mem_limit=container_config.mem_limit)
+        resources=docker.types.Resources(mem_limit=container_config.mem_limit),
+        restart_policy=docker.types.RestartPolicy(condition="none")
     )
 
     # Wait for the server to launch within the container before adding it


### PR DESCRIPTION
This PR fixes https://github.com/whole-tale/gwvolman/issues/144 and adds additional handling for container launch failures by
* Increasing launch timeout from 30s to 5m for very large images (looking at you, MATLAB)
* Raising an exception when the container enters a `failed` or `rejected` state
* Raising an exception when the container start exceeds the timeout
* Adding a restart policy with condition=none to prevent restart on failure