### PR TITLE
Use cached image if present

### DIFF
--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -328,10 +328,10 @@ def _build_image(cli, tale_id, image, tag, temp_dir, repo2docker_version):
                '--target-repo-dir="/home/jovyan/work/workspace" '
                '--user-id=1000 --user-name={} '
                '--no-clean --no-run --debug {} '
-               '--image-name {} {}'.format(
+               '--image-name {} --cache-from cache/{} {}'.format(
                                            image['config']['user'],
                                            extra_args,
-                                           tag, temp_dir))
+                                           tag, image['_id'], temp_dir))
 
     logging.info('Calling %s (%s)', r2d_cmd, tale_id)
 


### PR DESCRIPTION
**Problem**
Builds on nodes may not be using the pre-cached images (see https://github.com/whole-tale/gwvolman/pull/146).

**Approach**
Add the `--cache-from` argument to the r2d call to use the prebuilt `cache/imageId` image.

**Test**
tbd