### PR TITLE
Recorded run task

### DIFF
--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -21,7 +21,9 @@ except socket.gaierror:
 GIRDER_API_URL = os.environ.get("GIRDER_API_URL", DEFAULT_GIRDER_API_URL)
 LICENSE_PATH = os.environ.get("WT_LICENSE_PATH", "/licenses/")
 
-REPO2DOCKER_VERSION = "wholetale/repo2docker_wholetale:v1.0rc4"
+REPO2DOCKER_VERSION = "craigwillis/repo2docker_wholetale:reprozip"
+CPR_VERSION = "wholetale/cpr:latest"
+
 RUN_WT_BUTTON_IMG = (
     "https://img.shields.io/badge/WholeTale-Run!-579ACA.svg?"
     "logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABHNCSVQICAgIfAhki"

--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -21,8 +21,8 @@ except socket.gaierror:
 GIRDER_API_URL = os.environ.get("GIRDER_API_URL", DEFAULT_GIRDER_API_URL)
 LICENSE_PATH = os.environ.get("WT_LICENSE_PATH", "/licenses/")
 
-REPO2DOCKER_VERSION = "wholetale/repo2docker_wholetale:reprozip"
-CPR_VERSION = "wholetale/wt-cpr:latest"
+REPO2DOCKER_VERSION = os.environ.get("REPO2DOCKER_VERSION", "wholetale/repo2docker_wholetale:latest")
+CPR_VERSION = os.environ.get("CPR_VERSION", "wholetale/wt-cpr:latest")
 
 RUN_WT_BUTTON_IMG = (
     "https://img.shields.io/badge/WholeTale-Run!-579ACA.svg?"

--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -22,7 +22,7 @@ GIRDER_API_URL = os.environ.get("GIRDER_API_URL", DEFAULT_GIRDER_API_URL)
 LICENSE_PATH = os.environ.get("WT_LICENSE_PATH", "/licenses/")
 
 REPO2DOCKER_VERSION = "craigwillis/repo2docker_wholetale:reprozip"
-CPR_VERSION = "wholetale/cpr:latest"
+CPR_VERSION = "craigwillis/wt-cpr:latest"
 
 RUN_WT_BUTTON_IMG = (
     "https://img.shields.io/badge/WholeTale-Run!-579ACA.svg?"

--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -55,3 +55,11 @@ class TaleStatus(object):
     PREPARING = 0
     READY = 1
     ERROR = 2
+
+class RunStatus(object):
+    UNKNOWN = 0
+    STARTING = 1
+    RUNNING = 2
+    COMPLETED = 3
+    FAILED = 4
+    CANCELLED = 5

--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -21,8 +21,8 @@ except socket.gaierror:
 GIRDER_API_URL = os.environ.get("GIRDER_API_URL", DEFAULT_GIRDER_API_URL)
 LICENSE_PATH = os.environ.get("WT_LICENSE_PATH", "/licenses/")
 
-REPO2DOCKER_VERSION = "craigwillis/repo2docker_wholetale:reprozip"
-CPR_VERSION = "craigwillis/wt-cpr:latest"
+REPO2DOCKER_VERSION = "wholetale/repo2docker_wholetale:reprozip"
+CPR_VERSION = "wholetale/wt-cpr:latest"
 
 RUN_WT_BUTTON_IMG = (
     "https://img.shields.io/badge/WholeTale-Run!-579ACA.svg?"

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -86,12 +86,8 @@ def create_volume(self, instance_id):
     if ENABLE_WORKSPACES:
         work_dir = os.path.join(mountpoint, 'workspace')
 
-    # FUSE is silly and needs to have mirror inside container
-    for suffix in MOUNTPOINTS:
-        directory = os.path.join(mountpoint, suffix)
-        _safe_mkdir(HOSTDIR + directory)
-        if not os.path.isdir(directory):
-            os.makedirs(directory)
+    _make_fuse_dirs(mountpoint, MOUNTPOINTS)
+
     api_key = _get_api_key(self.girder_client)
 
     if tale.get('dataSet') is not None:
@@ -693,3 +689,13 @@ def _mount_girderfs(mountpoint, directory, fs_type, obj_id, api_key):
     logging.info("Calling: %s", cmd)
     subprocess.call(cmd, shell=True)
     print(f"Mounted {fs_type} {directory}")
+
+def _make_fuse_dirs(mountpoint, directories):
+    """Create fuse directories""" 
+
+    # FUSE is silly and needs to have mirror inside container
+    for suffix in directories:
+        directory = os.path.join(mountpoint, suffix)
+        _safe_mkdir(HOSTDIR + directory)
+        if not os.path.isdir(directory):
+            os.makedirs(directory)

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -730,9 +730,11 @@ def _get_session(gc, tale=None, version_id=None):
 
 
 def _write_env_json(workspace_dir, image):
-    dot_dir = f"{HOSTDIR}{workspace_dir}/.wholetale/"
-    _safe_mkdir(dot_dir)
-    env_json = os.path.join(dot_dir, 'environment.json')
+    #dot_dir = f"{HOSTDIR}{workspace_dir}/.wholetale/"
+    #_safe_mkdir(dot_dir)
+    #os.chown(dot_dir, DEFAULT_USER, DEFAULT_GROUP)
+    #env_json = os.path.join(dot_dir, 'environment.json')
+    env_json = os.path.join(f"{HOSTDIR}{workspace_dir}", 'environment.json')
 
     print(f"Dumping the environment to {env_json}")
     with open(env_json, 'w') as fp:
@@ -826,6 +828,7 @@ def recorded_run(self, run_id, tale_id):
             current=4, forceFlush=True)
 
     except Exception as e:
+        logging.exception("message")
         logging.error("Recorded run failed. %s", e)
         set_run_status(run, RunStatus.FAILED)
     finally:

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -166,7 +166,7 @@ def launch_container(self, payload):
     payload.update(attrs)
     payload['name'] = service.name
     return payload
-    
+
 @girder_job(title='Update Instance')
 @app.task(bind=True)
 def update_container(task, instanceId, digest=None):
@@ -616,6 +616,7 @@ def import_tale(self, lookup_kwargs, tale, spawn=True):
     # TODO: maybe filter results?
     return {'tale': tale, 'instance': instance}
 
+
 @app.task
 def rebuild_image_cache():
     logging.info("Rebuilding image cache")
@@ -654,6 +655,7 @@ def rebuild_image_cache():
 
         shutil.rmtree(temp_dir, ignore_errors=True)
 
+
 def _mount_girderfs(mountpoint, directory, fs_type, obj_id, api_key, hostns=False):
 
     hostns_flag = '--hostns' if hostns else ''
@@ -667,8 +669,9 @@ def _mount_girderfs(mountpoint, directory, fs_type, obj_id, api_key, hostns=Fals
     subprocess.call(cmd, shell=True)
     print(f"Mounted {fs_type} {directory}")
 
+
 def _make_fuse_dirs(mountpoint, directories):
-    """Create fuse directories""" 
+    """Create fuse directories"""
 
     # FUSE is silly and needs to have mirror inside container
     for suffix in directories:
@@ -676,6 +679,7 @@ def _make_fuse_dirs(mountpoint, directories):
         _safe_mkdir(HOSTDIR + directory)
         if not os.path.isdir(directory):
             os.makedirs(directory)
+
 
 def _create_docker_volume(cli, vol_name):
     """Creates a Docker volume with the specified name"""
@@ -705,6 +709,7 @@ def _create_docker_volume(cli, vol_name):
         subprocess.call('mount --bind {}/usr/local /usr/local'.format(libdir),
                         shell=True)
     return mountpoint
+
 
 def _get_session(gc, tale=None, version_id=None):
     """Returns the session for a tale or version"""
@@ -780,7 +785,7 @@ def recorded_run(self, run_id, tale_id):
     # Build currently assumes tmp directory, in this case mount the run workspace
     container_config = _get_container_config(self.girder_client, tale)
     work_target = os.path.join(container_config.target_mount, 'workspace')
-    extra_volume =  {
+    extra_volume = {
         work_dir: {
             'bind': work_target,
             'mode': 'rw'
@@ -805,6 +810,8 @@ def recorded_run(self, run_id, tale_id):
             message='Finished recorded run', total=RECORDED_RUN_STEP_TOTAL,
             current=4, forceFlush=True)
 
+    except Exception as e:
+        logging.error("Recorded run failed. %s", e)
     finally:
         # TODO: _cleanup_volumes
         for suffix in ['data', 'workspace']:

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -850,10 +850,10 @@ def recorded_run(self, run_id, tale_id):
         # Delete the Docker volume
         try:
             volume = cli.volumes.get(vol_name)
+            try:
+                logging.info("Removing volume: %s", volume.id)
+                volume.remove()
+            except Exception as e:
+                logging.error("Unable to remove volume [%s]: %s", volume.id, e)
         except docker.errors.NotFound:
             logging.info("Volume not present [%s].", vol_name)
-        try:
-            logging.info("Removing volume: %s", volume.id)
-            volume.remove()
-        except Exception as e:
-            logging.error("Unable to remove volume [%s]: %s", volume.id, e)

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -667,7 +667,7 @@ def _mount_girderfs(mountpoint, directory, fs_type, obj_id, api_key, hostns=Fals
         f" {os.path.join(mountpoint, directory)} {obj_id}"
     )
     logging.info("Calling: %s", cmd)
-    subprocess.call(cmd, shell=True)
+    subprocess.check_call(cmd, shell=True)
     print(f"Mounted {fs_type} {directory}")
 
 

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -767,8 +767,10 @@ def recorded_run(self, run_id, tale_id):
     # TODO: Need the environment.json in the workspace. Could be done via fuse.
     work_dir = os.path.join(mountpoint, 'workspace')
     image = self.girder_client.get('/image/%s' % tale['imageId'])
-    print("Dumping the environment to " + work_dir)
-    with open(os.path.join(HOSTDIR + work_dir, 'environment.json'), 'w') as fp:
+    wt_dir = f"{HOSTDIR}{work_dir}/.wholetale/"
+    _safe_mkdir(wt_dir)
+    print(f"Dumping the environment to {wt_dir}")
+    with open(os.path.join(wt_dir, 'environment.json'), 'w') as fp:
         json.dump(image, fp)
 
     # TODO: What should we use here? Latest? What the tale was built with?

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -730,13 +730,17 @@ def _get_session(gc, tale=None, version_id=None):
 
 
 def _write_env_json(workspace_dir, image):
-    #dot_dir = f"{HOSTDIR}{workspace_dir}/.wholetale/"
-    #_safe_mkdir(dot_dir)
-    #os.chown(dot_dir, DEFAULT_USER, DEFAULT_GROUP)
-    #env_json = os.path.join(dot_dir, 'environment.json')
-    env_json = os.path.join(f"{HOSTDIR}{workspace_dir}", 'environment.json')
+    # TODO: I wanted to write to the .wholetale directory, but this would 
+    # mean that the user's r2d config needs to be there too (e.g, apt.txt).
+    # So for now, write to root of workspace.
 
-    print(f"Dumping the environment to {env_json}")
+    env_json = os.path.join(f"{HOSTDIR}{workspace_dir}", 'environment.json')
+    # dot_dir = f"{HOSTDIR}{workspace_dir}/.wholetale/"
+    # _safe_mkdir(dot_dir)
+    # os.chown(dot_dir, DEFAULT_USER, DEFAULT_GROUP)
+    # env_json = os.path.join(dot_dir, 'environment.json')
+
+    print(f"Writing the environment to {env_json}")
     with open(env_json, 'w') as fp:
         json.dump(image, fp)
     return env_json

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -832,8 +832,8 @@ def recorded_run(self, run_id, tale_id):
             current=4, forceFlush=True)
 
     except Exception as e:
-        logging.exception("message")
         logging.error("Recorded run failed. %s", e)
+        logging.exception(e)
         set_run_status(run, RunStatus.FAILED)
     finally:
         # Remove the environment.json

--- a/gwvolman/tests/test_recorded_run.py
+++ b/gwvolman/tests/test_recorded_run.py
@@ -71,7 +71,7 @@ RPZ_RUN_CALL = mock.call(
     }
 )
 CPR_RUN_CALL = mock.call(
-    image='craigwillis/wt-cpr:latest',
+    image='wholetale/wt-cpr:latest',
     command='bash -c "/cpr/bin/run_reports.sh /work/workspace"',
     environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
     detach=True,

--- a/gwvolman/tests/test_recorded_run.py
+++ b/gwvolman/tests/test_recorded_run.py
@@ -1,7 +1,7 @@
 from girder_client import GirderClient
 import mock
 
-from gwvolman.tasks import recorded_run
+from gwvolman.tasks import recorded_run, _write_env_json
 from gwvolman.utils import ContainerConfig
 from gwvolman.constants import RunStatus
 
@@ -140,3 +140,17 @@ def test_recorded_run(mg, mfd, cdv, gs, wej, gak, gcc, bi, osr, sp, containers, 
         assert status == RunStatus.FAILED
 
     containers.run.assert_has_calls([RPZ_RUN_CALL], any_order=True)
+
+
+def test_write_env_json():
+    mock_image = {
+        '_id': 'image1', 
+        'name': 'Mock Image'
+    }
+
+    workspace_dir =  '/path/to/mountpoint/workspace'
+
+    with mock.patch('builtins.open', mock.mock_open()) as mock_open:
+        env_json = _write_env_json(workspace_dir, mock_image)
+
+        assert env_json == '/host/path/to/mountpoint/workspace/environment.json'

--- a/gwvolman/tests/test_recorded_run.py
+++ b/gwvolman/tests/test_recorded_run.py
@@ -1,0 +1,142 @@
+from girder_client import GirderClient
+import mock
+
+from gwvolman.tasks import recorded_run
+from gwvolman.utils import ContainerConfig
+from gwvolman.constants import RunStatus
+
+
+class MockVolume:
+    @property
+    def id(self):
+        return "abc"
+
+    def remove(self):
+        return True
+
+def mock_gc_patch(path, parameters=None):
+    global status
+    if path in "/run/123abc/status":
+        status = parameters["status"]
+        return 200
+
+
+def mock_gc_get(path, parameters=None):
+    if path in ("/image/abc123"):
+        return {"_id": "abc123", "buildPack": "JupyterBuildPack"}
+    elif path in ("/tale/abc123"):
+        return {"_id": "abc123", "imageId": "abc123"}
+    elif path in ("/user/me"):
+        return {"login": "user1"}
+    elif path in "/run/123abc":
+        return {"_id": "123abc", "name": "run1", "runVersionId": "xyz234"}
+
+
+CONTAINER_CONFIG = ContainerConfig(
+    buildpack="JupyterBuildPack",
+    repo2docker_version="wholetale/repo2docker_wholetale:latest",
+    image="abc123",
+    command="test",
+    mem_limit=2,
+    cpu_shares=1,
+    container_port=8080,
+    container_user="jovyan",
+    target_mount="/work",
+    url_path="",
+    environment=[],
+    csp=""
+)
+
+RPZ_RUN_CALL = mock.call(
+    image='registry.test.wholetale.org/123abc/1624994605',
+    command='bash -c "mkdir -p .wholetale/.reprozip-trace ;reprozip trace '
+            '--dir .wholetale/.reprozip-trace --overwrite ./run.sh"',
+    environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
+    cap_add = ['SYS_PTRACE'],
+    detach=True,
+    remove=True,
+    volumes={
+        '/var/run/docker.sock': {
+            'bind': '/var/run/docker.sock', 'mode': 'rw'
+        },
+        '/tmp': {
+            'bind': '/host/tmp', 'mode': 'ro'
+        },
+        '/path/to/mountpoint/data': {
+            'bind': '/work/data', 'mode': 'rw'
+        },
+        '/path/to/mountpoint/workspace': {
+            'bind': '/work/workspace', 'mode': 'rw'
+        }
+    }
+)
+CPR_RUN_CALL = mock.call(
+    image='craigwillis/wt-cpr:latest',
+    command='bash -c "/cpr/bin/run_reports.sh /work/workspace"',
+    environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
+    detach=True,
+    remove=True,
+    volumes={
+        '/var/run/docker.sock': {
+            'bind': '/var/run/docker.sock', 'mode': 'rw'
+        },
+        '/tmp': {
+            'bind': '/host/tmp', 'mode': 'ro'
+        },
+        '/path/to/mountpoint/data': {
+            'bind': '/work/data', 'mode': 'rw'
+        },
+        '/path/to/mountpoint/workspace': {
+            'bind': '/work/workspace', 'mode': 'rw'
+        }
+    }
+)
+
+
+@mock.patch("time.time", return_value=1624994605)
+@mock.patch("docker.client.DockerClient.volumes")
+@mock.patch("docker.client.DockerClient.containers")
+@mock.patch("subprocess.call", return_value=True)
+@mock.patch("os.remove", return_value=True)
+@mock.patch("gwvolman.tasks._build_image", return_value={"StatusCode": 0})
+@mock.patch("gwvolman.tasks._get_container_config", return_value=CONTAINER_CONFIG)
+@mock.patch("gwvolman.tasks._get_api_key", return_value="key123")
+@mock.patch("gwvolman.tasks._write_env_json", return_value="/path/to/environment.json")
+@mock.patch("gwvolman.tasks._get_session", return_value={"_id": None})
+@mock.patch("gwvolman.tasks._create_docker_volume", return_value="/path/to/mountpoint/")
+@mock.patch("gwvolman.tasks._make_fuse_dirs", return_value=True)
+@mock.patch("gwvolman.tasks._mount_girderfs", return_value=True)
+def test_recorded_run(mg, mfd, cdv, gs, wej, gak, gcc, bi, osr, sp, containers, volumes, time):
+
+    mock_gc = mock.MagicMock(spec=GirderClient)
+    mock_gc.get = mock_gc_get
+    mock_gc.patch = mock_gc_patch
+
+    recorded_run.girder_client = mock_gc
+    recorded_run.job_manager = mock.MagicMock()
+
+    volumes.get.return_value = MockVolume()
+
+    # This should succeed
+    containers.run.return_value.wait.return_value = {"StatusCode": 0}
+    try:
+        with mock.patch('gwvolman.utils.Deployment.registry_url', new_callable=mock.PropertyMock) as mock_dep:
+            mock_dep.return_value = 'https://registry.test.wholetale.org'
+            recorded_run("123abc", "abc123")
+            assert status == RunStatus.COMPLETED
+    except ValueError:
+        assert False
+
+    containers.run.assert_has_calls([RPZ_RUN_CALL, CPR_RUN_CALL], any_order=True)
+
+    # This should fail
+    containers.run.return_value.wait.return_value = {"StatusCode": 1}
+    try:
+        with mock.patch('gwvolman.utils.Deployment.registry_url', new_callable=mock.PropertyMock) as mock_dep:
+            mock_dep.return_value = 'https://registry.test.wholetale.org'
+            recorded_run("123abc", "abc123")
+    except ValueError:
+        assert True
+        assert status == RunStatus.FAILED
+
+    containers.run.assert_has_calls([RPZ_RUN_CALL], any_order=True)

--- a/gwvolman/tests/test_volumes.py
+++ b/gwvolman/tests/test_volumes.py
@@ -1,0 +1,161 @@
+from girder_client import GirderClient
+import mock
+import os
+
+os.environ['GIRDER_API_URL'] = 'https://girder.dev.wholetale.org/api/v1'
+
+from gwvolman.tasks import create_volume, _mount_girderfs, \
+    _make_fuse_dirs, _create_docker_volume, _get_session # noqa
+
+
+class MockVolume:
+    @property
+    def id(self):
+        return "abc"
+
+    @property
+    def name(self):
+        return "vol1"
+
+    def remove(self):
+        return True
+
+    @property
+    def attrs(self):
+        return {
+            'Mountpoint': '/var/lib/docker/volumes/vol1'
+        }
+
+
+def mock_gc_post(path, parameters=None):
+    if path in ("/dm/session"):
+        if 'taleId' in parameters:
+            return {"_id": "session1"}
+        elif 'dataSet' in parameters:
+            return {"_id": "session2"}
+
+
+def mock_gc_get(path, parameters=None):
+    if path in ("/instance/instance1"):
+        return {"_id": "instance1", "taleId": "tale1"}
+    elif path in ("/tale/tale1"):
+        return {"_id": "tale1"}
+    elif path in ("/user/me"):
+        return {"_id": "ghi567", "login": "user1"}
+    elif path in ("/version/version1/dataSet"):
+        return {}
+
+
+@mock.patch("gwvolman.tasks.new_user", return_value="123456")
+@mock.patch("docker.client.DockerClient.info", return_value={'Swarm': {'NodeID': 'node1'}})
+@mock.patch("docker.client.DockerClient.volumes")
+@mock.patch("gwvolman.tasks._get_api_key", return_value="apikey1")
+@mock.patch("gwvolman.tasks._get_session", return_value={"_id": "session1"})
+@mock.patch("gwvolman.tasks._create_docker_volume", return_value="/path/to/mountpoint/")
+@mock.patch("gwvolman.tasks._make_fuse_dirs", return_value=True)
+@mock.patch("gwvolman.tasks._mount_girderfs", return_value=True)
+def test_create_volume(mgfs, mfd, cdv, gs, gak, volumes, info, nu):
+
+    mock_gc = mock.MagicMock(spec=GirderClient)
+    mock_gc.get = mock_gc_get
+    mock_gc.loadOrCreateFolder = mock.Mock(return_value={'_id': 'folder1'})
+
+    create_volume.girder_client = mock_gc
+    create_volume.job_manager = mock.MagicMock()
+
+    volumes.get.return_value = MockVolume()
+
+    try:
+        ret = create_volume('instance1')
+
+        expected = {
+            'nodeId': 'node1',
+            'mountPoint': '/path/to/mountpoint/',
+            'volumeName': 'tale1_user1_123456',
+            'sessionId': 'session1',
+            'instanceId': 'instance1'
+        }
+
+        assert ret == expected
+    except ValueError:
+        assert False
+
+    mgfs.assert_has_calls([
+        mock.call('/path/to/mountpoint/', 'data', 'wt_dms', 'session1',
+                  'apikey1', hostns=True),
+        mock.call('/path/to/mountpoint/', 'home', 'wt_home', 'folder1', 'apikey1'),
+        mock.call('/path/to/mountpoint/', 'workspace', 'wt_work', 'tale1', 'apikey1'),
+        mock.call('/path/to/mountpoint/', 'versions', 'wt_versions', 'tale1',
+                  'apikey1', hostns=True)
+        ], any_order=False)
+
+
+@mock.patch("subprocess.check_call", return_value=True)
+def test_mount_girderfs(spcc):
+
+    _mount_girderfs('/path/to/mountpoint', 'home', 'wt_home', 'folder1', 'apikey1')
+
+    _mount_girderfs('/path/to/mountpoint', 'data', 'wt_dms', 'session1', 'apikey1', True)
+
+    spcc.assert_has_calls([
+        mock.call('girderfs  -c wt_home --api-url https://girder.dev.wholetale.org/api/v1'
+                  ' --api-key apikey1 /path/to/mountpoint/home folder1', shell=True),
+        mock.call('girderfs --hostns -c wt_dms --api-url https://girder.dev.wholetale.org/api/v1'
+                  ' --api-key apikey1 /path/to/mountpoint/data session1', shell=True)
+        ], any_order=False)
+
+
+@mock.patch("os.makedirs", return_value=True)
+@mock.patch("os.mkdir", return_value=True)
+def test_make_fuse_dirs(mkdir, makedirs):
+
+    with mock.patch('os.path.isdir', return_value=True):
+        _make_fuse_dirs('/path/to/mountpoint', ['dir1'])
+
+    mkdir.assert_has_calls([mock.call('/host/path/to/mountpoint/dir1')], any_order=False)
+
+    with mock.patch('os.path.isdir', return_value=False):
+        _make_fuse_dirs('/path/to/mountpoint', ['dir2'])
+
+    makedirs.assert_has_calls([mock.call('/path/to/mountpoint/dir2')], any_order=False)
+
+
+@mock.patch("builtins.open", mock.mock_open(read_data="overlay"))
+@mock.patch("os.chown", return_value=True)
+@mock.patch("docker.client.DockerClient")
+def test_create_docker_volume(cli, chown):
+
+    cli.volumes.create.return_value = MockVolume()
+
+    with mock.patch('os.walk') as mock_walk:
+        mock_walk.return_value = [('/var/lib/docker/volumes', ('vol1',), ('',))]
+
+        mountpoint = _create_docker_volume(cli, 'vol1')
+        assert mountpoint == '/var/lib/docker/volumes/vol1'
+    chown.assert_has_calls([
+        mock.call('/host/var/lib/docker/volumes/vol1', 1000, 100),
+        mock.call('/var/lib/docker/volumes/vol1', 1000, 100),
+        mock.call('/var/lib/docker/volumes/', 1000, 100)
+    ])
+
+
+def test_get_session():
+
+    mock_tale = {
+        '_id': 'tale1',
+        'dataSet': {
+            '_modelType': 'item',
+            'itemId': '60d4897ce13fb71b1c179fe4',
+            'mountPath': 'usco2000.xls'
+        }
+    }
+
+    mock_gc = mock.MagicMock(spec=GirderClient)
+    mock_gc.post = mock_gc_post
+    mock_gc.get = mock_gc_get
+
+    session1 = _get_session(mock_gc, tale=mock_tale)
+    assert session1['_id'] == 'session1'
+
+    session2 = _get_session(mock_gc, tale=None, version_id='version1')
+    assert session2['_id'] == 'session2'

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -391,17 +391,17 @@ def _recorded_run(cli, mountpoint, container_config, tag):
     # as if the author ran it from in the container.
 
     # TODO: use run config, not run.sh
-    rpz_cmd = 'bash -c "mkdir -p .cpr/.reprozip-trace ;'\
-              'reprozip trace --dir .cpr/.reprozip-trace --overwrite ./run.sh"'
+    rpz_cmd = 'bash -c "mkdir -p .wholetale/.reprozip-trace ;'\
+              'reprozip trace --dir .wholetale/.reprozip-trace --overwrite ./run.sh"'
 
     print("Running reprozip with command " + rpz_cmd)
     print("Running image " + tag)
 
-    # Runs a privileged container for PTRACE
     container = cli.containers.run(
         image=tag,
         command=rpz_cmd,
         environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
+        cap_add = ['SYS_PTRACE'],
         privileged=True,
         detach=True,
         remove=True,

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -397,12 +397,11 @@ def _recorded_run(cli, mountpoint, container_config, tag):
     print("Running reprozip with command " + rpz_cmd)
     print("Running image " + tag)
 
-    #    cap_add = ['SYS_PTRACE'],
     container = cli.containers.run(
         image=tag,
         command=rpz_cmd,
         environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
-        privileged=True,
+        cap_add = ['SYS_PTRACE'],
         detach=True,
         remove=True,
         volumes=volumes


### PR DESCRIPTION
**This PR**
* Implements the `recorded_run` task which:
   * Builds the image for the specified version/run
   * Mounts workspace and data for the specified version/run
   * Executes `reprozip --trace ... ./run.sh` using the user's image, which generates output in the run workspace `.wholetale` directory
   * Executes CPR reports which generate output into `.wholetale/.cpr` directory
* Also
  * Moves volume creation/mounting code into helper functions that can be used by new recorded_run task
  * Modifies _build_image helper to enable use by recorded_run task
  * Adds tests

**To Test**
* Depends on
  * https://github.com/whole-tale/wt_versioning/pull/29
  * https://github.com/whole-tale/repo2docker_wholetale/pull/21
  * https://github.com/whole-tale/wt-cpr
* Create a tale with an executable `run.sh` in the workspace root.  
   * TODO: This needs to change with the run configuration implementation
* Create a version and run (`POST /run`) for the version
* Change the main workspace in a way that would be detectable during the run (i.e., modify run.sh)
* Optionally `docker logs -f celery_worker` to see what's happening and any errors
* `POST /run/{id}/start`
* Confirm the following
  * Image is built using the run workspace for the selected version
  * `reprozip trace` executes successfully (`.wholetale/.reprozip-trace/trace.sqlite3` is present in run workspace
  *  `cpr` reports execute successfully (`.wholetale/.cpr/` contains `exec.txt`, `write.txt`, `read.txt`)

Note: The reports are POC for now.