### PR TITLE
Avoid hardcoding mountpoint

### DIFF
--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -228,8 +228,7 @@ def _launch_container(volumeName, nodeId, container_config, tale_id='', instance
     #                        target=container_config.target_mount)
     # ]
 
-    # FIXME: get mountPoint
-    source_mount = '/var/lib/docker/volumes/{}/_data'.format(volumeName)
+    source_mount = cli.volumes.get(volumeName).attrs["Mountpoint"]
     mounts = []
     volumes = _get_container_volumes(source_mount, container_config, MOUNTPOINTS)
     for source in volumes:


### PR DESCRIPTION
The day has come to fix that "FIXME"...

### How to test
1. Deploy and spawn instance. Check if volumes are mounted
2. (optionally) the really hard way would be to change `Docker Root Dir` and do 1. again, but IMHO that's a waste of time... (I tested this on .radiant)