### PR TITLE
Pass encoded STATA license as r2d build arg

### DIFF
--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -21,7 +21,7 @@ except socket.gaierror:
 GIRDER_API_URL = os.environ.get("GIRDER_API_URL", DEFAULT_GIRDER_API_URL)
 LICENSE_PATH = os.environ.get("WT_LICENSE_PATH", "/licenses/")
 
-REPO2DOCKER_VERSION = os.environ.get("REPO2DOCKER_VERSION", "craigwillis/repo2docker_wholetale:xfce")
+REPO2DOCKER_VERSION = os.environ.get("REPO2DOCKER_VERSION", "wholetale/repo2docker_wholetale:latest")
 CPR_VERSION = os.environ.get("CPR_VERSION", "wholetale/wt-cpr:latest")
 
 RUN_WT_BUTTON_IMG = (

--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -21,7 +21,7 @@ except socket.gaierror:
 GIRDER_API_URL = os.environ.get("GIRDER_API_URL", DEFAULT_GIRDER_API_URL)
 LICENSE_PATH = os.environ.get("WT_LICENSE_PATH", "/licenses/")
 
-REPO2DOCKER_VERSION = os.environ.get("REPO2DOCKER_VERSION", "wholetale/repo2docker_wholetale:latest")
+REPO2DOCKER_VERSION = os.environ.get("REPO2DOCKER_VERSION", "craigwillis/repo2docker_wholetale:xfce")
 CPR_VERSION = os.environ.get("CPR_VERSION", "wholetale/wt-cpr:latest")
 
 RUN_WT_BUTTON_IMG = (

--- a/gwvolman/tests/test_build_image.py
+++ b/gwvolman/tests/test_build_image.py
@@ -24,49 +24,30 @@ def mock_gc_get(path, parameters=None):
             raise ValueError(f"Unknown image '{env}'")
         return {
             "_id": env,
-            "config": {"builpack": f"{env.capitalize()}BuildPack", "user": "jovyan"},
+            "config": {"buildpack": f"{env.capitalize()}BuildPack", "user": "jovyan"},
         }
     elif path in ("/folder/workspace1"):
         return {
             "_id": "workspace1",
             "updated": "2",
         }
-    elif path in ("/tale/tale1"):
-        return {
-            "_id": "tale1",
-            "imageId": "jupyter",
-            "workspaceId": "workspace1",
-            "status": 1,
-            "imageInfo": {
-                "last_build": 1,
-                "imageId": "image1",
-                "repo2docker_version": "wholetale/r2d_wt",
+    elif path.startswith("/tale"):
+        tale_id = os.path.basename(path)
+        images = {"tale1": "jupyter", "tale2": "stata", "tale3": "matlab"}
+        try:
+            return {
+                "_id": tale_id,
+                "workspaceId": "workspace1",
+                "status": 1,
+                "imageId": images[tale_id],
+                "imageInfo": {
+                    "last_build": 1,
+                    "imageId": images[tale_id],
+                    "repo2docker_version": "wholetale/r2d_wt",
+                }
             }
-        }
-    elif path in ("/tale/tale2"):
-        return {
-            "_id": "tale2",
-            "imageId": "stata",
-            "workspaceId": "workspace1",
-            "status": 1,
-            "imageInfo": {
-                "last_build": 1,
-                "imageId": "stata",
-                "repo2docker_version": "wholetale/r2d_wt",
-            }
-        }
-    elif path in ("/tale/tale3"):
-        return {
-            "_id": "tale3",
-            "imageId": "matlab",
-            "workspaceId": "workspace1",
-            "status": 1,
-            "imageInfo": {
-                "last_build": 1,
-                "imageId": "matlab",
-                "repo2docker_version": "wholetale/r2d_wt",
-            }
-        }
+        except KeyError:
+            raise ValueError(f"Unknown tale '{tale_id}'")
     elif path in ("/user/me"):
         return {"login": "user1"}
 

--- a/gwvolman/tests/test_build_image.py
+++ b/gwvolman/tests/test_build_image.py
@@ -18,29 +18,13 @@ class MockVolume:
 
 
 def mock_gc_get(path, parameters=None):
-    if path in ("/image/jupyter"):
+    if path.startswith("/image"):
+        env = os.path.basename(path)
+        if env not in {"jupyter", "stata", "matlab"}:
+            raise ValueError(f"Unknown image '{env}'")
         return {
-            "_id": "jupyter",
-            "config": {
-                "buildpack": "JupyterBuildPack",
-                "user": "jovyan",
-            }
-        }
-    elif path in ("/image/stata"):
-        return {
-            "_id": "stata",
-            "config": {
-                "buildpack": "StataBuildPack",
-                "user": "jovyan",
-            }
-        }
-    elif path in ("/image/matlab"):
-        return {
-            "_id": "matlab",
-            "config": {
-                "buildpack": "MatlabBuildPack",
-                "user": "jovyan",
-            }
+            "_id": env,
+            "config": {"builpack": f"{env.capitalize()}BuildPack", "user": "jovyan"},
         }
     elif path in ("/folder/workspace1"):
         return {

--- a/gwvolman/tests/test_build_image.py
+++ b/gwvolman/tests/test_build_image.py
@@ -1,0 +1,225 @@
+from girder_client import GirderClient
+from docker import DockerClient, APIClient
+from gwvolman.utils import ContainerConfig
+import mock
+import girder_worker
+import os
+
+from gwvolman.tasks import build_tale_image
+
+
+class MockVolume:
+    @property
+    def id(self):
+        return "abc"
+
+    def remove(self):
+        return True
+
+
+def mock_gc_get(path, parameters=None):
+    if path in ("/image/jupyter"):
+        return {
+            "_id": "jupyter",
+            "config": {
+                "buildpack": "JupyterBuildPack",
+                "user": "jovyan",
+            }
+        }
+    elif path in ("/image/stata"):
+        return {
+            "_id": "stata",
+            "config": {
+                "buildpack": "StataBuildPack",
+                "user": "jovyan",
+            }
+        }
+    elif path in ("/image/matlab"):
+        return {
+            "_id": "matlab",
+            "config": {
+                "buildpack": "MatlabBuildPack",
+                "user": "jovyan",
+            }
+        }
+    elif path in ("/folder/workspace1"):
+        return {
+            "_id": "workspace1",
+            "updated": "2",
+        }
+    elif path in ("/tale/tale1"):
+        return {
+            "_id": "tale1",
+            "imageId": "jupyter",
+            "workspaceId": "workspace1",
+            "status": 1,
+            "imageInfo": {
+                "last_build": 1,
+                "imageId": "image1",
+                "repo2docker_version": "wholetale/r2d_wt",
+            }
+        }
+    elif path in ("/tale/tale2"):
+        return {
+            "_id": "tale2",
+            "imageId": "stata",
+            "workspaceId": "workspace1",
+            "status": 1,
+            "imageInfo": {
+                "last_build": 1,
+                "imageId": "stata",
+                "repo2docker_version": "wholetale/r2d_wt",
+            }
+        }
+    elif path in ("/tale/tale3"):
+        return {
+            "_id": "tale3",
+            "imageId": "matlab",
+            "workspaceId": "workspace1",
+            "status": 1,
+            "imageInfo": {
+                "last_build": 1,
+                "imageId": "matlab",
+                "repo2docker_version": "wholetale/r2d_wt",
+            }
+        }
+    elif path in ("/user/me"):
+        return {"login": "user1"}
+
+
+CONTAINER_CONFIG = ContainerConfig(
+    buildpack="JupyterBuildPack",
+    repo2docker_version="wholetale/repo2docker_wholetale:latest",
+    image="image1",
+    command="test",
+    mem_limit=2,
+    cpu_shares=1,
+    container_port=8080,
+    container_user="jovyan",
+    target_mount="/work",
+    url_path="",
+    environment=[],
+    csp=""
+)
+
+JUPYTER_R2D_CALL = mock.call(
+    image='wholetale/repo2docker_wholetale:latest',
+    command="jupyter-repo2docker --config='/wholetale/repo2docker_config.py'"
+            " --target-repo-dir='/home/jovyan/work/workspace'"
+            " --user-id=1000 --user-name=jovyan --no-clean --no-run --debug"
+            "  --image-name registry.test.wholetale.org/tale1/1624994605 /tmp/xxx",
+    environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
+    privileged=True,
+    detach=True,
+    remove=True,
+    volumes={
+        '/var/run/docker.sock': {
+            'bind': '/var/run/docker.sock',
+            'mode': 'rw'
+        },
+        '/tmp': {
+            'bind': '/host/tmp',
+            'mode': 'ro'
+        }
+    }
+)
+
+STATA_R2D_CALL = mock.call(
+    image='wholetale/repo2docker_wholetale:latest',
+    command="jupyter-repo2docker --config='/wholetale/repo2docker_config.py'"
+            " --target-repo-dir='/home/jovyan/work/workspace'"
+            " --user-id=1000 --user-name=jovyan --no-clean --no-run --debug"
+            "  --build-arg STATA_LICENSE_ENCODED='dGhpcyBpcyBhIGZha2Ugc3RhdGEgbGljZW5zZQo='"
+            "  --image-name registry.test.wholetale.org/tale2/1624994605 /tmp/xxx",
+    environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
+    privileged=True,
+    detach=True,
+    remove=True,
+    volumes={
+        '/var/run/docker.sock': {
+            'bind': '/var/run/docker.sock',
+            'mode': 'rw'
+        },
+        '/tmp': {
+            'bind': '/host/tmp',
+            'mode': 'ro'
+        }
+    }
+)
+
+MATLAB_R2D_CALL = mock.call(
+    image='wholetale/repo2docker_wholetale:latest',
+    command="jupyter-repo2docker --config='/wholetale/repo2docker_config.py'"
+            " --target-repo-dir='/home/jovyan/work/workspace'"
+            " --user-id=1000 --user-name=jovyan --no-clean --no-run --debug"
+            "  --build-arg FILE_INSTALLATION_KEY=fake-matlab-key"
+            "  --image-name registry.test.wholetale.org/tale3/1624994605 /tmp/xxx",
+    environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
+    privileged=True,
+    detach=True,
+    remove=True,
+    volumes={
+        '/var/run/docker.sock': {
+            'bind': '/var/run/docker.sock',
+            'mode': 'rw'
+        },
+        '/tmp': {
+            'bind': '/host/tmp',
+            'mode': 'ro'
+        }
+    }
+)
+
+
+@mock.patch.dict(os.environ, {"MATLAB_FILE_INSTALLATION_KEY": "fake-matlab-key"})
+@mock.patch("base64.b64encode", return_value=bytes("dGhpcyBpcyBhIGZha2Ugc3RhdGEgbGljZW5zZQo=",
+            encoding='ascii'))
+@mock.patch("time.time", return_value=1624994605)
+@mock.patch("docker.APIClient")
+@mock.patch("builtins.open", new_callable=mock.mock_open(), read_data=bytes("blah",
+            encoding="ascii"))
+@mock.patch("tempfile.mkdtemp", return_value="/tmp/xxx")
+@mock.patch("docker.DockerClient.containers")
+@mock.patch("docker.DockerClient.images")
+@mock.patch("docker.DockerClient.login")
+@mock.patch("shutil.rmtree", return_value=True)
+@mock.patch("gwvolman.tasks._get_container_config", return_value=CONTAINER_CONFIG)
+def test_build_tale_image(gcc, sh, dcl, dci, containers, tf, op, ac, time, b64):
+
+    mock_gc = mock.MagicMock(spec=GirderClient)
+    mock_gc.get = mock_gc_get
+    mock_gc.downloadFolderRecursive.return_value = True
+
+    build_tale_image.girder_client = mock_gc
+    build_tale_image.cli = mock.MagicMock(spec=DockerClient)
+    build_tale_image.cli.images.pull.return_value = True
+    build_tale_image.apicli = mock.MagicMock(spec=APIClient)
+    build_tale_image.job_manager = mock.MagicMock()
+    girder_worker.task.Task.canceled = mock.PropertyMock(return_value=False)
+
+    containers.run.return_value.wait.return_value = {"StatusCode": 0}
+
+    try:
+        with mock.patch("gwvolman.utils.Deployment.registry_url",
+                        new_callable=mock.PropertyMock) as mock_dep:
+
+            mock_dep.return_value = "https://registry.test.wholetale.org"
+
+            build_tale_image("tale1", force=False)
+            build_tale_image("tale2", force=False)
+            build_tale_image("tale3", force=False)
+
+    except ValueError:
+        assert False
+
+    containers.run.assert_has_calls(
+        [JUPYTER_R2D_CALL, mock.call().logs(stream=True),
+         mock.call().logs().__iter__(), mock.call().wait()])
+
+    containers.run.assert_has_calls(
+        [STATA_R2D_CALL, mock.call().logs(stream=True),
+         mock.call().logs().__iter__(), mock.call().wait()])
+
+    containers.run.assert_has_calls(
+        [MATLAB_R2D_CALL, mock.call().logs(stream=True),
+         mock.call().logs().__iter__(), mock.call().wait()])

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -14,6 +14,7 @@ import logging
 import docker
 import datetime
 import dateutil.relativedelta as rel
+import base64
 
 from .constants import LICENSE_PATH, MOUNTPOINTS, REPO2DOCKER_VERSION, CPR_VERSION
 
@@ -302,13 +303,22 @@ def _build_image(cli, tale_id, image, tag, build_dir, repo2docker_version, extra
     if image['config']['buildpack'] == "MatlabBuildPack":
         extra_args = ' --build-arg FILE_INSTALLATION_KEY={} '.format(
                 os.environ.get("MATLAB_FILE_INSTALLATION_KEY"))
+    elif image['config']['buildpack'] == "StataBuildPack":
+        # License is also needed at build time but can't easily
+        # be mounted. Pass it as a build arg
 
-    r2d_cmd = ('jupyter-repo2docker '
-               '--config="/wholetale/repo2docker_config.py" '
-               '--target-repo-dir="/home/jovyan/work/workspace" '
-               '--user-id=1000 --user-name={} '
-               '--no-clean --no-run --debug {} '
-               '--image-name {} {}'.format(
+        source_path = _get_stata_license_path()
+        with open("/host/" + source_path, "r") as license_file:
+            stata_license = license_file.read()
+            encoded = base64.b64encode(stata_license.encode("ascii")).decode("ascii")
+            extra_args = " --build-arg STATA_LICENSE_ENCODED='{}' ".format(encoded)
+
+    r2d_cmd = ("jupyter-repo2docker "
+               "--config='/wholetale/repo2docker_config.py' "
+               "--target-repo-dir='/home/jovyan/work/workspace' "
+               "--user-id=1000 --user-name={} "
+               "--no-clean --no-run --debug {} "
+               "--image-name {} {}".format(
                                            image['config']['user'],
                                            extra_args,
                                            tag, build_dir))
@@ -323,6 +333,7 @@ def _build_image(cli, tale_id, image, tag, build_dir, repo2docker_version, extra
             'bind': '/host/tmp', 'mode': 'ro'
         }
     }
+
     if extra_volume is not None:
         volumes.update(extra_volume)
 
@@ -371,10 +382,7 @@ def _get_container_volumes(mountpoint, container_config, directories):
             # Weekly license expires each Sunday and is provided
             # in the format stata.YYYYMMDD.lic where YYYYMMDD is the
             # license expiration date.
-            license_date = datetime.date.today() + rel.relativedelta(days=1, weekday=rel.SU)
-            source_path = os.path.join(
-                LICENSE_PATH, "stata", f"stata.{license_date.strftime('%Y%m%d')}.lic"
-            )
+            source_path = _get_stata_license_path()
             volumes[source_path] = {
                 'bind': '/usr/local/stata/stata.lic'
             }
@@ -440,3 +448,9 @@ def _recorded_run(cli, mountpoint, container_config, tag):
         raise ValueError('Error executing cpr for recorded run')
 
     return ret
+
+def _get_stata_license_path():
+    license_date = datetime.date.today() + rel.relativedelta(days=1, weekday=rel.SU)
+    return os.path.join(
+        LICENSE_PATH, "stata", f"stata.{license_date.strftime('%Y%m%d')}.lic"
+    )


### PR DESCRIPTION
See https://github.com/whole-tale/repo2docker_wholetale/pull/26 for test case.

To support installing custom STATA packages at build time (e.g., `install.do`) we need to provide the license file at build time.  I considered two options: 
1. using `RUN --mount` and copy the license from an image or 
2. pass the license as a build-arg. 

I went with option 2 here since we're already passing the MATLAB installation key as a build arg.  Because the license contains shell-interpretable characters (`$!`), I encode before passing and decode in the StataBuildPack.