### PR TITLE
Add runs volume

### DIFF
--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -12,6 +12,7 @@ MOUNTPOINTS = ["data", "home"]
 if ENABLE_WORKSPACES:
     MOUNTPOINTS.append("workspace")
     MOUNTPOINTS.append("versions")
+    MOUNTPOINTS.append("runs")
 
 
 try:

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -62,6 +62,7 @@ def create_volume(self, instance_id):
         'Home', user['_id'], 'user')
     data_dir = os.path.join(mountpoint, 'data')
     versions_dir = os.path.join(mountpoint, 'versions')
+    runs_dir = os.path.join(mountpoint, 'runs')
     if ENABLE_WORKSPACES:
         work_dir = os.path.join(mountpoint, 'workspace')
 
@@ -80,6 +81,7 @@ def create_volume(self, instance_id):
     if ENABLE_WORKSPACES:
         _mount_girderfs(mountpoint, 'workspace', 'wt_work', tale['_id'], api_key)
         _mount_girderfs(mountpoint, 'versions', 'wt_versions', tale['_id'], api_key, hostns=True)
+        _mount_girderfs(mountpoint, 'runs', 'wt_runs', tale['_id'], api_key, hostns=True)
 
     self.job_manager.updateProgress(
         message='Volume created', total=CREATE_VOLUME_STEP_TOTAL,

--- a/gwvolman/tests/test_volumes.py
+++ b/gwvolman/tests/test_volumes.py
@@ -86,7 +86,9 @@ def test_create_volume(mgfs, mfd, cdv, gs, gak, volumes, info, nu):
         mock.call('/path/to/mountpoint/', 'home', 'wt_home', 'folder1', 'apikey1'),
         mock.call('/path/to/mountpoint/', 'workspace', 'wt_work', 'tale1', 'apikey1'),
         mock.call('/path/to/mountpoint/', 'versions', 'wt_versions', 'tale1',
-                  'apikey1', hostns=True)
+                  'apikey1', hostns=True),
+        mock.call('/path/to/mountpoint/', 'runs', 'wt_runs', 'tale1', 'apikey1',
+                  hostns=True)
         ], any_order=False)
 
 


### PR DESCRIPTION
Adds the runs volume to the instance container.

To test:
* Requires https://github.com/whole-tale/girderfs/pull/29
* Start a tale instance
* Create a recorded run
* `ls ../runs` and confirm the run is there and accessible