### PR TITLE
enh: cache images based on r2d files checksum

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,6 +29,7 @@ lxml = "*"
 "dataone.common" = "==3.4.7"
 "dataone.libclient" = "==3.4.7"
 "dataone.cli" = "==3.4.7"
+pytest-pudb = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -29,7 +29,6 @@ lxml = "*"
 "dataone.common" = "==3.4.7"
 "dataone.libclient" = "==3.4.7"
 "dataone.cli" = "==3.4.7"
-pytest-pudb = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c6587eb84b327f854c98316f24ce36c6c307d798e6bf14a0d404bde5550d3fda"
+            "sha256": "d54dae239b67775adc28cce59b097d035b83ceaedfb28d774c9e517c56b3d5f7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,80 +18,80 @@
     "default": {
         "aiohttp": {
             "hashes": [
-                "sha256:09754a0d5eaab66c37591f2f8fac8f9781a5f61d51aa852a3261c4805ca6b984",
-                "sha256:097ecf52f6b9859b025c1e36401f8aa4573552e887d1b91b4b999d68d0b5a3b3",
-                "sha256:0a96473a1f61d7920a9099bc8e729dc8282539d25f79c12573ee0fdb9c8b66a8",
-                "sha256:0af379221975054162959e00daf21159ff69a712fc42ed0052caddbd70d52ff4",
-                "sha256:0d7b056fd3972d353cb4bc305c03f9381583766b7f8c7f1c44478dba69099e33",
-                "sha256:14a6f026eca80dfa3d52e86be89feb5cd878f6f4a6adb34457e2c689fd85229b",
-                "sha256:15a660d06092b7c92ed17c1dbe6c1eab0a02963992d60e3e8b9d5fa7fa81f01e",
-                "sha256:1fa9f50aa1f114249b7963c98e20dc35c51be64096a85bc92433185f331de9cc",
-                "sha256:257f4fad1714d26d562572095c8c5cd271d5a333252795cb7a002dca41fdbad7",
-                "sha256:28369fe331a59d80393ec82df3d43307c7461bfaf9217999e33e2acc7984ff7c",
-                "sha256:2bdd655732e38b40f8a8344d330cfae3c727fb257585df923316aabbd489ccb8",
-                "sha256:2f44d1b1c740a9e2275160d77c73a11f61e8a916191c572876baa7b282bcc934",
-                "sha256:3ba08a71caa42eef64357257878fb17f3fba3fba6e81a51d170e32321569e079",
-                "sha256:3c5e9981e449d54308c6824f172ec8ab63eb9c5f922920970249efee83f7e919",
-                "sha256:3f58aa995b905ab82fe228acd38538e7dc1509e01508dcf307dad5046399130f",
-                "sha256:48c996eb91bfbdab1e01e2c02e7ff678c51e2b28e3a04e26e41691991cc55795",
-                "sha256:48f218a5257b6bc16bcf26a91d97ecea0c7d29c811a90d965f3dd97c20f016d6",
-                "sha256:4a6551057a846bf72c7a04f73de3fcaca269c0bd85afe475ceb59d261c6a938c",
-                "sha256:51f90dabd9933b1621260b32c2f0d05d36923c7a5a909eb823e429dba0fd2f3e",
-                "sha256:577cc2c7b807b174814dac2d02e673728f2e46c7f90ceda3a70ea4bb6d90b769",
-                "sha256:5d79174d96446a02664e2bffc95e7b6fa93b9e6d8314536c5840dff130d0878b",
-                "sha256:5e3f81fbbc170418e22918a9585fd7281bbc11d027064d62aa4b507552c92671",
-                "sha256:5ecffdc748d3b40dd3618ede0170e4f5e1d3c9647cfb410d235d19e62cb54ee0",
-                "sha256:63fa57a0708573d3c059f7b5527617bd0c291e4559298473df238d502e4ab98c",
-                "sha256:67ca7032dfac8d001023fadafc812d9f48bf8a8c3bb15412d9cdcf92267593f4",
-                "sha256:688a1eb8c1a5f7e795c7cb67e0fe600194e6723ba35f138dfae0db20c0cb8f94",
-                "sha256:6a038cb1e6e55b26bb5520ccffab7f539b3786f5553af2ee47eb2ec5cbd7084e",
-                "sha256:6b79f6c31e68b6dafc0317ec453c83c86dd8db1f8f0c6f28e97186563fca87a0",
-                "sha256:6d3e027fe291b77f6be9630114a0200b2c52004ef20b94dc50ca59849cd623b3",
-                "sha256:6f1d39a744101bf4043fa0926b3ead616607578192d0a169974fb5265ab1e9d2",
-                "sha256:707adc30ea6918fba725c3cb3fe782d271ba352b22d7ae54a7f9f2e8a8488c41",
-                "sha256:730b7c2b7382194d9985ffdc32ab317e893bca21e0665cb1186bdfbb4089d990",
-                "sha256:764c7c6aa1f78bd77bd9674fc07d1ec44654da1818d0eef9fb48aa8371a3c847",
-                "sha256:78d51e35ed163783d721b6f2ce8ce3f82fccfe471e8e50a10fba13a766d31f5a",
-                "sha256:7a315ceb813208ef32bdd6ec3a85cbe3cb3be9bbda5fd030c234592fa9116993",
-                "sha256:7ba09bb3dcb0b7ec936a485db2b64be44fe14cdce0a5eac56f50e55da3627385",
-                "sha256:7d76e8a83396e06abe3df569b25bd3fc88bf78b7baa2c8e4cf4aaf5983af66a3",
-                "sha256:84fe1732648c1bc303a70faa67cbc2f7f2e810c8a5bca94f6db7818e722e4c0a",
-                "sha256:871d4fdc56288caa58b1094c20f2364215f7400411f76783ea19ad13be7c8e19",
-                "sha256:88d4917c30fcd7f6404fb1dc713fa21de59d3063dcc048f4a8a1a90e6bbbd739",
-                "sha256:8a50150419b741ee048b53146c39c47053f060cb9d98e78be08fdbe942eaa3c4",
-                "sha256:90a97c2ed2830e7974cbe45f0838de0aefc1c123313f7c402e21c29ec063fbb4",
-                "sha256:949a605ef3907254b122f845baa0920407080cdb1f73aa64f8d47df4a7f4c4f9",
-                "sha256:9689af0f0a89e5032426c143fa3683b0451f06c83bf3b1e27902bd33acfae769",
-                "sha256:98b1ea2763b33559dd9ec621d67fc17b583484cb90735bfb0ec3614c17b210e4",
-                "sha256:9951c2696c4357703001e1fe6edc6ae8e97553ac630492ea1bf64b429cb712a3",
-                "sha256:9a52b141ff3b923a9166595de6e3768a027546e75052ffba267d95b54267f4ab",
-                "sha256:9e8723c3256641e141cd18f6ce478d54a004138b9f1a36e41083b36d9ecc5fc5",
-                "sha256:a2fee4d656a7cc9ab47771b2a9e8fad8a9a33331c1b59c3057ecf0ac858f5bfe",
-                "sha256:a4759e85a191de58e0ea468ab6fd9c03941986eee436e0518d7a9291fab122c8",
-                "sha256:a5399a44a529083951b55521cf4ecbf6ad79fd54b9df57dbf01699ffa0549fc9",
-                "sha256:a6074a3b2fa2d0c9bf0963f8dfc85e1e54a26114cc8594126bc52d3fa061c40e",
-                "sha256:a84c335337b676d832c1e2bc47c3a97531b46b82de9f959dafb315cbcbe0dfcd",
-                "sha256:adf0cb251b1b842c9dee5cfcdf880ba0aae32e841b8d0e6b6feeaef002a267c5",
-                "sha256:b76669b7c058b8020b11008283c3b8e9c61bfd978807c45862956119b77ece45",
-                "sha256:bda75d73e7400e81077b0910c9a60bf9771f715420d7e35fa7739ae95555f195",
-                "sha256:be03a7483ad9ea60388f930160bb3728467dd0af538aa5edc60962ee700a0bdc",
-                "sha256:c62d4791a8212c885b97a63ef5f3974b2cd41930f0cd224ada9c6ee6654f8150",
-                "sha256:cb751ef712570d3bda9a73fd765ff3e1aba943ec5d52a54a0c2e89c7eef9da1e",
-                "sha256:d3b19d8d183bcfd68b25beebab8dc3308282fe2ca3d6ea3cb4cd101b3c279f8d",
-                "sha256:d3f90ee275b1d7c942e65b5c44c8fb52d55502a0b9a679837d71be2bd8927661",
-                "sha256:d5f8c04574efa814a24510122810e3a3c77c0552f9f6ff65c9862f1f046be2c3",
-                "sha256:d6a1a66bb8bac9bc2892c2674ea363486bfb748b86504966a390345a11b1680e",
-                "sha256:d7715daf84f10bcebc083ad137e3eced3e1c8e7fa1f096ade9a8d02b08f0d91c",
-                "sha256:dafc01a32b4a1d7d3ef8bfd3699406bb44f7b2e0d3eb8906d574846e1019b12f",
-                "sha256:dcc4d5dd5fba3affaf4fd08f00ef156407573de8c63338787614ccc64f96b321",
-                "sha256:de42f513ed7a997bc821bddab356b72e55e8396b1b7ba1bf39926d538a76a90f",
-                "sha256:e27cde1e8d17b09730801ce97b6e0c444ba2a1f06348b169fd931b51d3402f0d",
-                "sha256:ecb314e59bedb77188017f26e6b684b1f6d0465e724c3122a726359fa62ca1ba",
-                "sha256:f348ebd20554e8bc26e8ef3ed8a134110c0f4bf015b3b4da6a4ddf34e0515b19",
-                "sha256:fa818609357dde5c4a94a64c097c6404ad996b1d38ca977a72834b682830a722",
-                "sha256:fe4a327da0c6b6e59f2e474ae79d6ee7745ac3279fd15f200044602fa31e3d79"
+                "sha256:01d7bdb774a9acc838e6b8f1d114f45303841b89b95984cbb7d80ea41172a9e3",
+                "sha256:03a6d5349c9ee8f79ab3ff3694d6ce1cfc3ced1c9d36200cb8f08ba06bd3b782",
+                "sha256:04d48b8ce6ab3cf2097b1855e1505181bdd05586ca275f2505514a6e274e8e75",
+                "sha256:0770e2806a30e744b4e21c9d73b7bee18a1cfa3c47991ee2e5a65b887c49d5cf",
+                "sha256:07b05cd3305e8a73112103c834e91cd27ce5b4bd07850c4b4dbd1877d3f45be7",
+                "sha256:086f92daf51a032d062ec5f58af5ca6a44d082c35299c96376a41cbb33034675",
+                "sha256:099ebd2c37ac74cce10a3527d2b49af80243e2a4fa39e7bce41617fbc35fa3c1",
+                "sha256:0c7ebbbde809ff4e970824b2b6cb7e4222be6b95a296e46c03cf050878fc1785",
+                "sha256:102e487eeb82afac440581e5d7f8f44560b36cf0bdd11abc51a46c1cd88914d4",
+                "sha256:11691cf4dc5b94236ccc609b70fec991234e7ef8d4c02dd0c9668d1e486f5abf",
+                "sha256:11a67c0d562e07067c4e86bffc1553f2cf5b664d6111c894671b2b8712f3aba5",
+                "sha256:12de6add4038df8f72fac606dff775791a60f113a725c960f2bab01d8b8e6b15",
+                "sha256:13487abd2f761d4be7c8ff9080de2671e53fff69711d46de703c310c4c9317ca",
+                "sha256:15b09b06dae900777833fe7fc4b4aa426556ce95847a3e8d7548e2d19e34edb8",
+                "sha256:1c182cb873bc91b411e184dab7a2b664d4fea2743df0e4d57402f7f3fa644bac",
+                "sha256:1ed0b6477896559f17b9eaeb6d38e07f7f9ffe40b9f0f9627ae8b9926ae260a8",
+                "sha256:28d490af82bc6b7ce53ff31337a18a10498303fe66f701ab65ef27e143c3b0ef",
+                "sha256:2e5d962cf7e1d426aa0e528a7e198658cdc8aa4fe87f781d039ad75dcd52c516",
+                "sha256:2ed076098b171573161eb146afcb9129b5ff63308960aeca4b676d9d3c35e700",
+                "sha256:2f2f69dca064926e79997f45b2f34e202b320fd3782f17a91941f7eb85502ee2",
+                "sha256:31560d268ff62143e92423ef183680b9829b1b482c011713ae941997921eebc8",
+                "sha256:31d1e1c0dbf19ebccbfd62eff461518dcb1e307b195e93bba60c965a4dcf1ba0",
+                "sha256:37951ad2f4a6df6506750a23f7cbabad24c73c65f23f72e95897bb2cecbae676",
+                "sha256:3af642b43ce56c24d063325dd2cf20ee012d2b9ba4c3c008755a301aaea720ad",
+                "sha256:44db35a9e15d6fe5c40d74952e803b1d96e964f683b5a78c3cc64eb177878155",
+                "sha256:473d93d4450880fe278696549f2e7aed8cd23708c3c1997981464475f32137db",
+                "sha256:477c3ea0ba410b2b56b7efb072c36fa91b1e6fc331761798fa3f28bb224830dd",
+                "sha256:4a4a4e30bf1edcad13fb0804300557aedd07a92cabc74382fdd0ba6ca2661091",
+                "sha256:4aed991a28ea3ce320dc8ce655875e1e00a11bdd29fe9444dd4f88c30d558602",
+                "sha256:51467000f3647d519272392f484126aa716f747859794ac9924a7aafa86cd411",
+                "sha256:55c3d1072704d27401c92339144d199d9de7b52627f724a949fc7d5fc56d8b93",
+                "sha256:589c72667a5febd36f1315aa6e5f56dd4aa4862df295cb51c769d16142ddd7cd",
+                "sha256:5bfde62d1d2641a1f5173b8c8c2d96ceb4854f54a44c23102e2ccc7e02f003ec",
+                "sha256:5c23b1ad869653bc818e972b7a3a79852d0e494e9ab7e1a701a3decc49c20d51",
+                "sha256:61bfc23df345d8c9716d03717c2ed5e27374e0fe6f659ea64edcd27b4b044cf7",
+                "sha256:6ae828d3a003f03ae31915c31fa684b9890ea44c9c989056fea96e3d12a9fa17",
+                "sha256:6c7cefb4b0640703eb1069835c02486669312bf2f12b48a748e0a7756d0de33d",
+                "sha256:6d69f36d445c45cda7b3b26afef2fc34ef5ac0cdc75584a87ef307ee3c8c6d00",
+                "sha256:6f0d5f33feb5f69ddd57a4a4bd3d56c719a141080b445cbf18f238973c5c9923",
+                "sha256:6f8b01295e26c68b3a1b90efb7a89029110d3a4139270b24fda961893216c440",
+                "sha256:713ac174a629d39b7c6a3aa757b337599798da4c1157114a314e4e391cd28e32",
+                "sha256:718626a174e7e467f0558954f94af117b7d4695d48eb980146016afa4b580b2e",
+                "sha256:7187a76598bdb895af0adbd2fb7474d7f6025d170bc0a1130242da817ce9e7d1",
+                "sha256:71927042ed6365a09a98a6377501af5c9f0a4d38083652bcd2281a06a5976724",
+                "sha256:7d08744e9bae2ca9c382581f7dce1273fe3c9bae94ff572c3626e8da5b193c6a",
+                "sha256:7dadf3c307b31e0e61689cbf9e06be7a867c563d5a63ce9dca578f956609abf8",
+                "sha256:81e3d8c34c623ca4e36c46524a3530e99c0bc95ed068fd6e9b55cb721d408fb2",
+                "sha256:844a9b460871ee0a0b0b68a64890dae9c415e513db0f4a7e3cab41a0f2fedf33",
+                "sha256:8b7ef7cbd4fec9a1e811a5de813311ed4f7ac7d93e0fda233c9b3e1428f7dd7b",
+                "sha256:97ef77eb6b044134c0b3a96e16abcb05ecce892965a2124c566af0fd60f717e2",
+                "sha256:99b5eeae8e019e7aad8af8bb314fb908dd2e028b3cdaad87ec05095394cce632",
+                "sha256:a25fa703a527158aaf10dafd956f7d42ac6d30ec80e9a70846253dd13e2f067b",
+                "sha256:a2f635ce61a89c5732537a7896b6319a8fcfa23ba09bec36e1b1ac0ab31270d2",
+                "sha256:a79004bb58748f31ae1cbe9fa891054baaa46fb106c2dc7af9f8e3304dc30316",
+                "sha256:a996d01ca39b8dfe77440f3cd600825d05841088fd6bc0144cc6c2ec14cc5f74",
+                "sha256:b0e20cddbd676ab8a64c774fefa0ad787cc506afd844de95da56060348021e96",
+                "sha256:b6613280ccedf24354406caf785db748bebbddcf31408b20c0b48cb86af76866",
+                "sha256:b9d00268fcb9f66fbcc7cd9fe423741d90c75ee029a1d15c09b22d23253c0a44",
+                "sha256:bb01ba6b0d3f6c68b89fce7305080145d4877ad3acaed424bae4d4ee75faa950",
+                "sha256:c2aef4703f1f2ddc6df17519885dbfa3514929149d3ff900b73f45998f2532fa",
+                "sha256:c34dc4958b232ef6188c4318cb7b2c2d80521c9a56c52449f8f93ab7bc2a8a1c",
+                "sha256:c3630c3ef435c0a7c549ba170a0633a56e92629aeed0e707fec832dee313fb7a",
+                "sha256:c3d6a4d0619e09dcd61021debf7059955c2004fa29f48788a3dfaf9c9901a7cd",
+                "sha256:d15367ce87c8e9e09b0f989bfd72dc641bcd04ba091c68cd305312d00962addd",
+                "sha256:d2f9b69293c33aaa53d923032fe227feac867f81682f002ce33ffae978f0a9a9",
+                "sha256:e999f2d0e12eea01caeecb17b653f3713d758f6dcc770417cf29ef08d3931421",
+                "sha256:ea302f34477fda3f85560a06d9ebdc7fa41e82420e892fc50b577e35fc6a50b2",
+                "sha256:eaba923151d9deea315be1f3e2b31cc39a6d1d2f682f942905951f4e40200922",
+                "sha256:ef9612483cb35171d51d9173647eed5d0069eaa2ee812793a75373447d487aa4",
+                "sha256:f5315a2eb0239185af1bddb1abf472d877fede3cc8d143c6cddad37678293237",
+                "sha256:fa0ffcace9b3aa34d205d8130f7873fcfefcb6a4dd3dd705b0dab69af6712642",
+                "sha256:fc5471e1a54de15ef71c1bc6ebe80d4dc681ea600e68bfd1cbce40427f0b7578"
             ],
-            "version": "==3.8.0"
+            "version": "==3.8.1"
         },
         "aiosignal": {
             "hashes": [
@@ -109,10 +109,10 @@
         },
         "async-timeout": {
             "hashes": [
-                "sha256:7d87a4e8adba8ededb52e579ce6bc8276985888913620c935094c2276fd83382",
-                "sha256:f3303dddf6cafa748a92747ab6c2ecf60e0aeca769aee4c151adfce243a05d9b"
+                "sha256:a22c0b311af23337eb05fcf05a8b51c3ea53729d46fb5460af62bee033cec690",
+                "sha256:b930cb161a39042f9222f6efb7301399c87eeab394727ec5437924a36d6eef51"
             ],
-            "version": "==4.0.0"
+            "version": "==4.0.1"
         },
         "attrs": {
             "hashes": [
@@ -402,6 +402,13 @@
             "markers": "python_version >= '3'",
             "version": "==3.3"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
         "iso8601": {
             "hashes": [
                 "sha256:22c7de877cfcbbcf241b4aa3934a1fa1fb6b200b242dbb054e438a9e5af56ce0",
@@ -415,6 +422,13 @@
                 "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
             ],
             "version": "==0.6.0"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93",
+                "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"
+            ],
+            "version": "==0.18.0"
         },
         "jsonpickle": {
             "hashes": [
@@ -597,12 +611,39 @@
             ],
             "version": "==21.2"
         },
+        "parso": {
+            "hashes": [
+                "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398",
+                "sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22"
+            ],
+            "version": "==0.8.2"
+        },
         "pbr": {
             "hashes": [
                 "sha256:4651ca1445e80f2781827305de3d76b3ce53195f2227762684eb08f17bc473b7",
                 "sha256:60002958e459b195e8dbe61bf22bcf344eedf1b4e03a321a5414feb15566100c"
             ],
             "version": "==5.7.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+            ],
+            "version": "==1.0.0"
+        },
+        "pudb": {
+            "hashes": [
+                "sha256:82a524ab4b89d2c701b089071ccc6afa9c8a838504e3d68eb33faa8a8abbe4cb"
+            ],
+            "version": "==2021.2.2"
+        },
+        "py": {
+            "hashes": [
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+            ],
+            "version": "==1.11.0"
         },
         "pyasn1": {
             "hashes": [
@@ -624,6 +665,13 @@
             ],
             "index": "pypi",
             "version": "==7.44.1"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380",
+                "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"
+            ],
+            "version": "==2.10.0"
         },
         "pyjwt": {
             "hashes": [
@@ -758,6 +806,21 @@
             ],
             "version": "==2.4.7"
         },
+        "pytest": {
+            "hashes": [
+                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
+                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+            ],
+            "version": "==6.2.5"
+        },
+        "pytest-pudb": {
+            "hashes": [
+                "sha256:0ea87316d39c82163d340c28a168e08a163b8d3f484e60a53c9fd5eefe432c63",
+                "sha256:21e96fc16f313a7bd75e1df1b151de8a721144318b0ae8350208d6554222005a"
+            ],
+            "index": "pypi",
+            "version": "==0.7.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
@@ -872,6 +935,13 @@
             ],
             "version": "==3.5.0"
         },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "version": "==0.10.2"
+        },
         "tomli": {
             "hashes": [
                 "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee",
@@ -881,11 +951,10 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
-                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
-                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
+                "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed",
+                "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"
             ],
-            "version": "==3.10.0.2"
+            "version": "==4.0.0"
         },
         "urllib3": {
             "hashes": [
@@ -893,6 +962,18 @@
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
             "version": "==1.26.7"
+        },
+        "urwid": {
+            "hashes": [
+                "sha256:588bee9c1cb208d0906a9f73c613d2bd32c3ed3702012f51efe318a3f2127eae"
+            ],
+            "version": "==2.1.2"
+        },
+        "urwid-readline": {
+            "hashes": [
+                "sha256:018020cbc864bb5ed87be17dc26b069eae2755cb29f3a9c569aac3bded1efaf4"
+            ],
+            "version": "==0.13"
         },
         "vine": {
             "hashes": [
@@ -1028,54 +1109,55 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:0147f7833c41927d84f5af9219d9b32f875c0689e5e74ac8ca3cb61e73a698f9",
-                "sha256:04a92a6cf9afd99f9979c61348ec79725a9f9342fb45e63c889e33c04610d97b",
-                "sha256:10ab138b153e4cc408b43792cb7f518f9ee02f4ff55cd1ab67ad6fd7e9905c7e",
-                "sha256:2e5b9c17a56b8bf0c0a9477fcd30d357deb486e4e1b389ed154f608f18556c8a",
-                "sha256:326d944aad0189603733d646e8d4a7d952f7145684da973c463ec2eefe1387c2",
-                "sha256:359a32515e94e398a5c0fa057e5887a42e647a9502d8e41165cf5cb8d3d1ca67",
-                "sha256:35cd2230e1ed76df7d0081a997f0fe705be1f7d8696264eb508076e0d0b5a685",
-                "sha256:3b270c6b48d3ff5a35deb3648028ba2643ad8434b07836782b1139cf9c66313f",
-                "sha256:42a1fb5dee3355df90b635906bb99126faa7936d87dfc97eacc5293397618cb7",
-                "sha256:479228e1b798d3c246ac89b09897ee706c51b3e5f8f8d778067f38db73ccc717",
-                "sha256:4cd919057636f63ab299ccb86ea0e78b87812400c76abab245ca385f17d19fb5",
-                "sha256:4d8b453764b9b26b0dd2afb83086a7c3f9379134e340288d2a52f8a91592394b",
-                "sha256:51a441011a30d693e71dea198b2a6f53ba029afc39f8e2aeb5b77245c1b282ef",
-                "sha256:557594a50bfe3fb0b1b57460f6789affe8850ad19c1acf2d14a3e12b2757d489",
-                "sha256:572f917267f363101eec375c109c9c1118037c7cc98041440b5eabda3185ac7b",
-                "sha256:62512c0ec5d307f56d86504c58eace11c1bc2afcdf44e3ff20de8ca427ca1d0e",
-                "sha256:65ad3ff837c89a229d626b8004f0ee32110f9bfdb6a88b76a80df36ccc60d926",
-                "sha256:666c6b32b69e56221ad1551d377f718ed00e6167c7a1b9257f780b105a101271",
-                "sha256:6e994003e719458420e14ffb43c08f4c14990e20d9e077cb5cad7a3e419bbb54",
-                "sha256:72bf437d54186d104388cbae73c9f2b0f8a3e11b6e8d7deb593bd14625c96026",
-                "sha256:738e823a746841248b56f0f3bd6abf3b73af191d1fd65e4c723b9c456216f0ad",
-                "sha256:78287731e3601ea5ce9d6468c82d88a12ef8fe625d6b7bdec9b45d96c1ad6533",
-                "sha256:7833c872718dc913f18e51ee97ea0dece61d9930893a58b20b3daf09bb1af6b6",
-                "sha256:7e083d32965d2eb6638a77e65b622be32a094fdc0250f28ce6039b0732fbcaa8",
-                "sha256:8186b5a4730c896cbe1e4b645bdc524e62d874351ae50e1db7c3e9f5dc81dc26",
-                "sha256:8605add58e6a960729aa40c0fd9a20a55909dd9b586d3e8104cc7f45869e4c6b",
-                "sha256:977ce557d79577a3dd510844904d5d968bfef9489f512be65e2882e1c6eed7d8",
-                "sha256:994ce5a7b3d20981b81d83618aa4882f955bfa573efdbef033d5632b58597ba9",
-                "sha256:9ad5895938a894c368d49d8470fe9f519909e5ebc6b8f8ea5190bd0df6aa4271",
-                "sha256:9eb0a1923354e0fdd1c8a6f53f5db2e6180d670e2b587914bf2e79fa8acfd003",
-                "sha256:a00284dbfb53b42e35c7dd99fc0e26ef89b4a34efff68078ed29d03ccb28402a",
-                "sha256:a11a2c019324fc111485e79d55907e7289e53d0031275a6c8daed30690bc50c0",
-                "sha256:ab6a0fe4c96f8058d41948ddf134420d3ef8c42d5508b5a341a440cce7a37a1d",
-                "sha256:b1d0a1bce919de0dd8da5cff4e616b2d9e6ebf3bd1410ff645318c3dd615010a",
-                "sha256:b8e4f15b672c9156c1154249a9c5746e86ac9ae9edc3799ee3afebc323d9d9e0",
-                "sha256:bbca34dca5a2d60f81326d908d77313816fad23d11b6069031a3d6b8c97a54f9",
-                "sha256:bf656cd74ff7b4ed7006cdb2a6728150aaad69c7242b42a2a532f77b63ea233f",
-                "sha256:c95257aa2ccf75d3d91d772060538d5fea7f625e48157f8ca44594f94d41cb33",
-                "sha256:dc5023be1c2a8b0a0ab5e31389e62c28b2453eb31dd069f4b8d1a0f9814d951a",
-                "sha256:e14bceb1f3ae8a14374be2b2d7bc12a59226872285f91d66d301e5f41705d4d6",
-                "sha256:e3c4f5211394cd0bf6874ac5d29684a495f9c374919833dcfff0bd6d37f96201",
-                "sha256:e76f017b6d4140a038c5ff12be1581183d7874e41f1c0af58ecf07748d36a336",
-                "sha256:e7d5606b9240ed4def9cbdf35be4308047d11e858b9c88a6c26974758d6225ce",
-                "sha256:f0f80e323a17af63eac6a9db0c9188c10f1fd815c3ab299727150cc0eb92c7a4",
-                "sha256:fb2fa2f6506c03c48ca42e3fe5a692d7470d290c047ee6de7c0f3e5fa7639ac9",
-                "sha256:ffa8fee2b1b9e60b531c4c27cf528d6b5d5da46b1730db1f4d6eee56ff282e07"
+                "sha256:046647b96969fda1ae0605f61288635209dd69dcd27ba3ec0bf5148bc157f954",
+                "sha256:06d009e8a29483cbc0520665bc46035ffe9ae0e7484a49f9782c2a716e37d0a0",
+                "sha256:0cde7d9fe2fb55ff68ebe7fb319ef188e9b88e0a3d1c9c5db7dd829cd93d2193",
+                "sha256:1de9c6f5039ee2b1860b7bad2c7bc3651fbeb9368e4c4d93e98a76358cdcb052",
+                "sha256:24ed38ec86754c4d5a706fbd5b52b057c3df87901a8610d7e5642a08ec07087e",
+                "sha256:27a3df08a855522dfef8b8635f58bab81341b2fb5f447819bc252da3aa4cf44c",
+                "sha256:310c40bed6b626fd1f463e5a83dba19a61c4eb74e1ac0d07d454ebbdf9047e9d",
+                "sha256:3348865798c077c695cae00da0924136bb5cc501f236cfd6b6d9f7a3c94e0ec4",
+                "sha256:35b246ae3a2c042dc8f410c94bcb9754b18179cdb81ff9477a9089dbc9ecc186",
+                "sha256:3f546f48d5d80a90a266769aa613bc0719cb3e9c2ef3529d53f463996dd15a9d",
+                "sha256:586d38dfc7da4a87f5816b203ff06dd7c1bb5b16211ccaa0e9788a8da2b93696",
+                "sha256:5d3855d5d26292539861f5ced2ed042fc2aa33a12f80e487053aed3bcb6ced13",
+                "sha256:610c0ba11da8de3a753dc4b1f71894f9f9debfdde6559599f303286e70aeb0c2",
+                "sha256:62646d98cf0381ffda301a816d6ac6c35fc97aa81b09c4c52d66a15c4bef9d7c",
+                "sha256:66af99c7f7b64d050d37e795baadf515b4561124f25aae6e1baa482438ecc388",
+                "sha256:675adb3b3380967806b3cbb9c5b00ceb29b1c472692100a338730c1d3e59c8b9",
+                "sha256:6e5a8c947a2a89c56655ecbb789458a3a8e3b0cbf4c04250331df8f647b3de59",
+                "sha256:7a39590d1e6acf6a3c435c5d233f72f5d43b585f5be834cff1f21fec4afda225",
+                "sha256:80cb70264e9a1d04b519cdba3cd0dc42847bf8e982a4d55c769b9b0ee7cdce1e",
+                "sha256:82fdcb64bf08aa5db881db061d96db102c77397a570fbc112e21c48a4d9cb31b",
+                "sha256:8492d37acdc07a6eac6489f6c1954026f2260a85a4c2bb1e343fe3d35f5ee21a",
+                "sha256:94f558f8555e79c48c422045f252ef41eb43becdd945e9c775b45ebfc0cbd78f",
+                "sha256:958ac66272ff20e63d818627216e3d7412fdf68a2d25787b89a5c6f1eb7fdd93",
+                "sha256:95a58336aa111af54baa451c33266a8774780242cab3704b7698d5e514840758",
+                "sha256:96129e41405887a53a9cc564f960d7f853cc63d178f3a182fdd302e4cab2745b",
+                "sha256:97ef6e9119bd39d60ef7b9cd5deea2b34869c9f0b9777450a7e3759c1ab09b9b",
+                "sha256:98d44a8136eebbf544ad91fef5bd2b20ef0c9b459c65a833c923d9aa4546b204",
+                "sha256:9d2c2e3ce7b8cc932a2f918186964bd44de8c84e2f9ef72dc616f5bb8be22e71",
+                "sha256:a300b39c3d5905686c75a369d2a66e68fd01472ea42e16b38c948bd02b29e5bd",
+                "sha256:a34fccb45f7b2d890183a263578d60a392a1a218fdc12f5bce1477a6a68d4373",
+                "sha256:a4d48e42e17d3de212f9af44f81ab73b9378a4b2b8413fd708d0d9023f2bbde4",
+                "sha256:af45eea024c0e3a25462fade161afab4f0d9d9e0d5a5d53e86149f74f0a35ecc",
+                "sha256:ba6125d4e55c0b8e913dad27b22722eac7abdcb1f3eab1bd090eee9105660266",
+                "sha256:bc1ee1318f703bc6c971da700d74466e9b86e0c443eb85983fb2a1bd20447263",
+                "sha256:c18725f3cffe96732ef96f3de1939d81215fd6d7d64900dcc4acfe514ea4fcbf",
+                "sha256:c8e9c4bcaaaa932be581b3d8b88b677489975f845f7714efc8cce77568b6711c",
+                "sha256:cc799916b618ec9fd00135e576424165691fec4f70d7dc12cfaef09268a2478c",
+                "sha256:cd2d11a59afa5001ff28073ceca24ae4c506da4355aba30d1e7dd2bd0d2206dc",
+                "sha256:d0a595a781f8e186580ff8e3352dd4953b1944289bec7705377c80c7e36c4d6c",
+                "sha256:d3c5f49ce6af61154060640ad3b3281dbc46e2e0ef2fe78414d7f8a324f0b649",
+                "sha256:d9a635114b88c0ab462e0355472d00a180a5fbfd8511e7f18e4ac32652e7d972",
+                "sha256:e5432d9c329b11c27be45ee5f62cf20a33065d482c8dec1941d6670622a6fb8f",
+                "sha256:eab14fdd410500dae50fd14ccc332e65543e7b39f6fc076fe90603a0e5d2f929",
+                "sha256:ebcc03e1acef4ff44f37f3c61df478d6e469a573aa688e5a162f85d7e4c3860d",
+                "sha256:fae3fe111670e51f1ebbc475823899524e3459ea2db2cb88279bbfb2a0b8a3de",
+                "sha256:fd92ece726055e80d4e3f01fff3b91f54b18c9c357c48fcf6119e87e2461a091",
+                "sha256:ffa545230ca2ad921ad066bf8fd627e7be43716b6e0fcf8e32af1b8188ccb0ab"
             ],
-            "version": "==6.1.1"
+            "version": "==6.1.2"
         },
         "flake8": {
             "hashes": [
@@ -1170,7 +1252,6 @@
                 "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
                 "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
             ],
-            "index": "pypi",
             "version": "==6.2.5"
         },
         "pytest-cov": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d54dae239b67775adc28cce59b097d035b83ceaedfb28d774c9e517c56b3d5f7"
+            "sha256": "c6587eb84b327f854c98316f24ce36c6c307d798e6bf14a0d404bde5550d3fda"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -91,6 +91,7 @@
                 "sha256:fa0ffcace9b3aa34d205d8130f7873fcfefcb6a4dd3dd705b0dab69af6712642",
                 "sha256:fc5471e1a54de15ef71c1bc6ebe80d4dc681ea600e68bfd1cbce40427f0b7578"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==3.8.1"
         },
         "aiosignal": {
@@ -98,6 +99,7 @@
                 "sha256:26e62109036cd181df6e6ad646f91f0dcfd05fe16d0cb924138ff2ab75d64e3a",
                 "sha256:78ed67db6c7b7ced4f98e495e572106d5c432a93e1ddd1bf475e1dc05f5b7df2"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.2.0"
         },
         "amqp": {
@@ -105,6 +107,7 @@
                 "sha256:70cdb10628468ff14e57ec2f751c7aa9e48e7e3651cfd62d431213c0c4e58f21",
                 "sha256:aa7f313fb887c91f15474c1229907a04dac0b8135822d6603437803424c0aa59"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.6.1"
         },
         "async-timeout": {
@@ -112,6 +115,7 @@
                 "sha256:a22c0b311af23337eb05fcf05a8b51c3ea53729d46fb5460af62bee033cec690",
                 "sha256:b930cb161a39042f9222f6efb7301399c87eeab394727ec5437924a36d6eef51"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==4.0.1"
         },
         "attrs": {
@@ -119,6 +123,7 @@
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
                 "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
         },
         "billiard": {
@@ -211,6 +216,7 @@
                 "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
                 "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==8.0.3"
         },
         "cryptography": {
@@ -236,6 +242,7 @@
                 "sha256:eb80e8a1f91e4b7ef8b33041591e6d89b2b8e122d787e87eeb2b08da71bb16ad",
                 "sha256:ebeddd119f526bcf323a89f853afb12e225902a24d29b55fe18dd6fcb2838a76"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==35.0.0"
         },
         "dataone.cli": {
@@ -264,6 +271,7 @@
                 "sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374",
                 "sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==5.1.0"
         },
         "diskcache": {
@@ -271,6 +279,7 @@
                 "sha256:1805acd5868ac10ad547208951a1190a0ab7bbff4e70f9a07cde4dbdfaa69f64",
                 "sha256:6e8137c778fd2752b93c8a8f944e939b3665d645b46774d8537dd3528ac3baa1"
             ],
+            "markers": "python_version >= '3'",
             "version": "==5.2.1"
         },
         "docker": {
@@ -278,6 +287,7 @@
                 "sha256:7a79bb439e3df59d0a72621775d600bc8bc8b422d285824cb37103eab91d1ce0",
                 "sha256:d916a26b62970e7c2f554110ed6af04c7ccff8e9f81ad17d0d40c75637e227fb"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==5.0.3"
         },
         "frozenlist": {
@@ -355,6 +365,7 @@
                 "sha256:f5f3b2942c3b8b9bfe76b408bbaba3d3bb305ee3693e8b1d631fe0a0d4f93673",
                 "sha256:fbd4844ff111449f3bbe20ba24fbb906b5b1c2384d0f3287c9f7da2354ce6d23"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.2.0"
         },
         "fusepy": {
@@ -368,6 +379,7 @@
             "hashes": [
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.18.2"
         },
         "girder-client": {
@@ -402,18 +414,20 @@
             "markers": "python_version >= '3'",
             "version": "==3.3"
         },
-        "iniconfig": {
+        "importlib-metadata": {
             "hashes": [
-                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+                "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100",
+                "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"
             ],
-            "version": "==1.1.1"
+            "markers": "python_version < '3.10'",
+            "version": "==4.8.2"
         },
         "iso8601": {
             "hashes": [
                 "sha256:22c7de877cfcbbcf241b4aa3934a1fa1fb6b200b242dbb054e438a9e5af56ce0",
                 "sha256:79ec9749f8bf35ffae77f835e80e96d2f95affa0f79d3d7b25c0fa7e06207a8b"
             ],
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.2'",
             "version": "==1.0.0"
         },
         "isodate": {
@@ -423,18 +437,12 @@
             ],
             "version": "==0.6.0"
         },
-        "jedi": {
-            "hashes": [
-                "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93",
-                "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"
-            ],
-            "version": "==0.18.0"
-        },
         "jsonpickle": {
             "hashes": [
                 "sha256:0be49cba80ea6f87a168aa8168d717d00c6ca07ba83df3cec32d3b30bfe6fb9a",
                 "sha256:c1010994c1fbda87a48f8a56698605b598cb0fc6bb7e7927559fc1100e69aeac"
             ],
+            "markers": "python_version >= '2.7'",
             "version": "==2.0.0"
         },
         "kombu": {
@@ -513,11 +521,11 @@
         },
         "markdown": {
             "hashes": [
-                "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49",
-                "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"
+                "sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006",
+                "sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3"
             ],
             "index": "pypi",
-            "version": "==3.3.4"
+            "version": "==3.3.6"
         },
         "multidict": {
             "hashes": [
@@ -594,61 +602,50 @@
                 "sha256:fc66d4016f6e50ed36fb39cd287a3878ffcebfa90008535c62e0e90a7ab713ae",
                 "sha256:fd77c8f3cba815aa69cb97ee2b2ef385c7c12ada9c734b0f3b32e26bb88bbf1d"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==5.2.0"
         },
         "networkx": {
             "hashes": [
                 "sha256:0d0e70e10dfb47601cbb3425a00e03e2a2e97477be6f80638fef91d54dd1e4b8",
                 "sha256:1b229b54fe9ccb009cee4de02a88552191497a542a7d5d34adab216b9f15c1ff",
+                "sha256:38e6bd32c0a2ad26439489d9b51e2684c01f352b536aaabbe499a3ad8c89f52b",
+                "sha256:3fbc044a40bc847ae28b65850b759f3d6c697ee7ff459a02dc8f8bc4d849dc7e",
                 "sha256:b3e0144d5fe6b7479b694e1b598a5545a38f3fc6f1e3c09173eb30f0c7a5770e"
             ],
             "version": "==1.11"
         },
         "packaging": {
             "hashes": [
-                "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966",
-                "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "version": "==21.2"
-        },
-        "parso": {
-            "hashes": [
-                "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398",
-                "sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22"
-            ],
-            "version": "==0.8.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
         },
         "pbr": {
             "hashes": [
-                "sha256:4651ca1445e80f2781827305de3d76b3ce53195f2227762684eb08f17bc473b7",
-                "sha256:60002958e459b195e8dbe61bf22bcf344eedf1b4e03a321a5414feb15566100c"
+                "sha256:176e8560eaf61e127817ef93d8a844803abb27a4d4637f0ff3bb783129be2e0a",
+                "sha256:672d8ebee84921862110f23fcec2acea191ef58543d34dfe9ef3d9f13c31cddf"
             ],
-            "version": "==5.7.0"
-        },
-        "pluggy": {
-            "hashes": [
-                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
-                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
-            ],
-            "version": "==1.0.0"
-        },
-        "pudb": {
-            "hashes": [
-                "sha256:82a524ab4b89d2c701b089071ccc6afa9c8a838504e3d68eb33faa8a8abbe4cb"
-            ],
-            "version": "==2021.2.2"
-        },
-        "py": {
-            "hashes": [
-                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
-            ],
-            "version": "==1.11.0"
+            "markers": "python_version >= '2.6'",
+            "version": "==5.8.0"
         },
         "pyasn1": {
             "hashes": [
+                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
+                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
+                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
+                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
                 "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
-                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
+                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
+                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
+                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
+                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
+                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
+                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
+                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
             ],
             "version": "==0.4.8"
         },
@@ -666,18 +663,12 @@
             "index": "pypi",
             "version": "==7.44.1"
         },
-        "pygments": {
-            "hashes": [
-                "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380",
-                "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"
-            ],
-            "version": "==2.10.0"
-        },
         "pyjwt": {
             "hashes": [
                 "sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41",
                 "sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==2.3.0"
         },
         "pymongo": {
@@ -764,6 +755,7 @@
                 "sha256:b1e6d1cf4bd6552b5f519432cce1530c09e6b0aab98d44803b991f7e880bd332",
                 "sha256:bf2d9d62178bb5c05e77d40becf89c309b1966fbcfb5c306238f81bf1ec2d6a2",
                 "sha256:bfd073fea04061019a103a288847846b5ef40dfa2f73b940ed61e399ca95314f",
+                "sha256:c04e84ccf590933a266180286d8b6a5fc844078a5d934432628301bd8b5f9ca7",
                 "sha256:c0947d7be30335cb4c3d5d0983d8ebc8294ae52503cf1d596c926f7e7183900b",
                 "sha256:c2a17752f97a942bdb4ff4a0516a67c5ade1658ebe1ab2edacdec0b42e39fa75",
                 "sha256:c4653830375ab019b86d218c749ad38908b74182b2863d09936aa8d7f990d30e",
@@ -801,25 +793,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
-            "version": "==2.4.7"
-        },
-        "pytest": {
-            "hashes": [
-                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
-                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
-            ],
-            "version": "==6.2.5"
-        },
-        "pytest-pudb": {
-            "hashes": [
-                "sha256:0ea87316d39c82163d340c28a168e08a163b8d3f484e60a53c9fd5eefe432c63",
-                "sha256:21e96fc16f313a7bd75e1df1b151de8a721144318b0ae8350208d6554222005a"
-            ],
-            "index": "pypi",
-            "version": "==0.7.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.6"
         },
         "python-dateutil": {
             "hashes": [
@@ -886,6 +864,7 @@
                 "sha256:6136ae056001474ee2aff5fc5b956e62a11c3a9c66bb0f3d9c0aaa5fbb56854e",
                 "sha256:b7642daac8cdad1ba157fecb236f5d1b2aa1de64e714dcee80d65e2b794d88a6"
             ],
+            "markers": "python_version >= '3.7'",
             "version": "==6.0.2"
         },
         "redis": {
@@ -897,9 +876,7 @@
             "version": "==3.5.3"
         },
         "requests": {
-            "extras": [
-                "security"
-            ],
+            "extras": [],
             "hashes": [
                 "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
                 "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
@@ -914,11 +891,20 @@
             ],
             "version": "==0.9.1"
         },
+        "setuptools": {
+            "hashes": [
+                "sha256:94ee891f4759150cded601a6beb6b08400413aefd0267b692f3f8c6e0bb238e7",
+                "sha256:fb537610c2dfe77b5896e3ee53dd53fbdd9adc48076c8f28cee3a30fb59a5038"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==59.1.1"
+        },
         "setuptools-scm": {
             "hashes": [
                 "sha256:4c64444b1d49c4063ae60bfe1680f611c8b13833d556fd1d6050c0023162a119",
                 "sha256:a49aa8081eeb3514eb9728fa5040f2eaa962d6c6f4ec9c32f6c1fba88f88a0f2"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==6.3.2"
         },
         "six": {
@@ -926,6 +912,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "stevedore": {
@@ -933,20 +920,15 @@
                 "sha256:a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c",
                 "sha256:f40253887d8712eaa2bb0ea3830374416736dc8ec0e22f5a65092c1174c44335"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==3.5.0"
-        },
-        "toml": {
-            "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
-            ],
-            "version": "==0.10.2"
         },
         "tomli": {
             "hashes": [
                 "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee",
                 "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.2.2"
         },
         "typing-extensions": {
@@ -954,6 +936,7 @@
                 "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed",
                 "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==4.0.0"
         },
         "urllib3": {
@@ -961,25 +944,15 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.7"
-        },
-        "urwid": {
-            "hashes": [
-                "sha256:588bee9c1cb208d0906a9f73c613d2bd32c3ed3702012f51efe318a3f2127eae"
-            ],
-            "version": "==2.1.2"
-        },
-        "urwid-readline": {
-            "hashes": [
-                "sha256:018020cbc864bb5ed87be17dc26b069eae2755cb29f3a9c569aac3bded1efaf4"
-            ],
-            "version": "==0.13"
         },
         "vine": {
             "hashes": [
                 "sha256:133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87",
                 "sha256:ea4947cc56d1fd6f2095c8d543ee25dad966f78692528e68b4fada11ba3f98af"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.3.0"
         },
         "websocket-client": {
@@ -987,6 +960,7 @@
                 "sha256:0133d2f784858e59959ce82ddac316634229da55b498aac311f1620567a710ec",
                 "sha256:8dfb715d8a992f5712fff8c843adae94e22b22a99b2c5e6b0ec4a1a981cc4e0d"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.2.1"
         },
         "yarl": {
@@ -1064,7 +1038,16 @@
                 "sha256:fce78593346c014d0d986b7ebc80d782b7f5e19843ca798ed62f8e3ba8728576",
                 "sha256:fd547ec596d90c8676e369dd8a581a21227fe9b4ad37d0dc7feb4ccf544c2d59"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.7.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
+                "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.6.0"
         },
         "zipstream": {
             "hashes": [
@@ -1079,6 +1062,7 @@
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
                 "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
         },
         "certifi": {
@@ -1099,6 +1083,7 @@
         "codecov": {
             "hashes": [
                 "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47",
+                "sha256:782a8e5352f22593cbc5427a35320b99490eb24d9dcfa2155fd99d2b75cfb635",
                 "sha256:a0da46bb5025426da895af90938def8ee12d37fcbcbbbc15b6dc64cf7ebc51c1"
             ],
             "index": "pypi",
@@ -1157,6 +1142,7 @@
                 "sha256:fd92ece726055e80d4e3f01fff3b91f54b18c9c357c48fcf6119e87e2461a091",
                 "sha256:ffa545230ca2ad921ad066bf8fd627e7be43716b6e0fcf8e32af1b8188ccb0ab"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==6.1.2"
         },
         "flake8": {
@@ -1207,16 +1193,18 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966",
-                "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "version": "==21.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
         },
         "pluggy": {
             "hashes": [
                 "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
                 "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.0.0"
         },
         "py": {
@@ -1224,6 +1212,7 @@
                 "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
                 "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.11.0"
         },
         "pycodestyle": {
@@ -1231,6 +1220,7 @@
                 "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
                 "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.8.0"
         },
         "pyflakes": {
@@ -1238,20 +1228,23 @@
                 "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
                 "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
-            "version": "==2.4.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.6"
         },
         "pytest": {
             "hashes": [
                 "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
                 "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
             ],
+            "index": "pypi",
             "version": "==6.2.5"
         },
         "pytest-cov": {
@@ -1263,9 +1256,7 @@
             "version": "==3.0.0"
         },
         "requests": {
-            "extras": [
-                "security"
-            ],
+            "extras": [],
             "hashes": [
                 "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
                 "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
@@ -1278,6 +1269,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "tomli": {
@@ -1285,6 +1277,7 @@
                 "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee",
                 "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.2.2"
         },
         "urllib3": {
@@ -1292,6 +1285,7 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.7"
         }
     }

--- a/gwvolman/build_utils.py
+++ b/gwvolman/build_utils.py
@@ -112,10 +112,12 @@ class ImageBuilder:
         using files from 1).
         """
         env_hash = hashlib.md5("Environment checksum".encode())
-        for fname in os.listdir(self.build_context):
-            env_hash.update(fname.encode())
-            with open(os.path.join(self.build_context, fname), "rb") as fp:
-                env_hash.update(fp.read())
+        for root, dirs, files in os.walk(self.build_context):
+            dirs.sort()
+            for fname in sorted(files):
+                env_hash.update(fname.encode())
+                with open(os.path.join(root, fname), "rb") as fp:
+                    env_hash.update(fp.read())
         if force and self.tale["_id"]:
             env_hash.update(self.tale["_id"].encode())
 

--- a/gwvolman/build_utils.py
+++ b/gwvolman/build_utils.py
@@ -9,20 +9,20 @@ import tempfile
 from urllib.parse import urlparse
 
 from .constants import R2D_FILENAMES
-from .utils import _get_container_config, DEPLOYMENT, \
-    HOSTDIR, REGISTRY_USER, REGISTRY_PASS, \
-    _get_stata_license_path
+from .utils import _get_container_config, DEPLOYMENT, _get_stata_license_path
 
 
 class DockerHelper:
     def __init__(self):
+        username = os.environ.get("REGISTRY_USER", "fido")
+        password = os.environ.get("REGISTRY_PASS")
         self.cli = docker.from_env(version='1.28')
         self.cli.login(
-            username=REGISTRY_USER, password=REGISTRY_PASS, registry=DEPLOYMENT.registry_url
+            username=username, password=password, registry=DEPLOYMENT.registry_url
         )
         self.apicli = docker.APIClient(base_url="unix://var/run/docker.sock")
         self.apicli.login(
-            username=REGISTRY_USER, password=REGISTRY_PASS, registry=DEPLOYMENT.registry_url
+            username=username, password=password, registry=DEPLOYMENT.registry_url
         )
 
 
@@ -60,7 +60,7 @@ class ImageBuilder:
             )
 
     def _create_build_context(self):
-        temp_dir = tempfile.mkdtemp(dir=HOSTDIR + "/tmp")
+        temp_dir = tempfile.mkdtemp(dir=os.environ.get("HOSTDIR", "/host") + "/tmp")
         logging.info("Downloading r2d files to %s (taleId:%s)", temp_dir, self.tale["_id"])
         extra_build_files = self.tale["config"].get("extra_build_files", [])
         workspaceId = self.tale.get("workspaceId")

--- a/gwvolman/build_utils.py
+++ b/gwvolman/build_utils.py
@@ -1,0 +1,219 @@
+import base64
+import docker
+import hashlib
+import json
+import logging
+import os
+import shutil
+import tempfile
+from urllib.parse import urlparse
+
+from .constants import R2D_FILENAMES
+from .utils import _get_container_config, DEPLOYMENT, \
+    HOSTDIR, REGISTRY_USER, REGISTRY_PASS, \
+    _get_stata_license_path
+
+
+class DockerHelper:
+    def __init__(self):
+        self.cli = docker.from_env(version='1.28')
+        self.cli.login(
+            username=REGISTRY_USER, password=REGISTRY_PASS, registry=DEPLOYMENT.registry_url
+        )
+        self.apicli = docker.APIClient(base_url="unix://var/run/docker.sock")
+        self.apicli.login(
+            username=REGISTRY_USER, password=REGISTRY_PASS, registry=DEPLOYMENT.registry_url
+        )
+
+
+class ImageBuilder:
+    _build_context = None
+
+    @property
+    def build_context(self):
+        if not self._build_context:
+            self._build_context = self._create_build_context()
+        return self._build_context
+
+    def __init__(self, gc, imageId=None, tale=None):
+        if (imageId is None) == (tale is None):
+            raise ValueError("Only one of 'imageId' and 'tale' can be set")
+
+        self.gc = gc
+        self.dh = DockerHelper()
+        if tale is None:
+            tale = {
+                "_id": None,
+                "imageId": imageId,
+                "workspaceId": None,
+                "config": {"extra_build_files": []},
+            }
+        self.tale = tale
+        self.container_config = _get_container_config(gc, self.tale)
+
+    def pull_r2d(self):
+        try:
+            self.dh.cli.images.pull(self.container_config.repo2docker_version)
+        except docker.errors.NotFound:
+            raise ValueError(
+                f"Requested r2d image '{self.container_config.repo2docker_version}' not found."
+            )
+
+    def _create_build_context(self):
+        temp_dir = tempfile.mkdtemp(dir=HOSTDIR + "/tmp")
+        logging.info("Downloading r2d files to %s (taleId:%s)", temp_dir, self.tale["_id"])
+        extra_build_files = self.tale["config"].get("extra_build_files", [])
+        workspaceId = self.tale.get("workspaceId")
+        if workspaceId:
+            if "**" in extra_build_files:
+                # A special case when we want to have an entire workspace in the build context
+                self.gc.downloadFolderRecursive(workspaceId, temp_dir)
+            else:
+                # Download standard r2d files
+                for name in R2D_FILENAMES:
+                    if item := next(self.gc.listItem(workspaceId, name=name), None):
+                        self.gc.downloadItem(item["_id"], temp_dir)
+                # Download any extra files specified by the Tale's config
+                root_path = self.gc.get(
+                    f"/resource/{workspaceId}/path", parameters={"type": "folder"}
+                )
+                for path in extra_build_files:
+                    if resource := self.gc.get(
+                        "/resource/lookup",
+                        parameters={
+                            "path": os.path.join(root_path, path),
+                            "test": False,
+                        },
+                    ):
+                        if resource["_modelType"] == "item":
+                            self.gc.downloadItem(resource["_id"], temp_dir)
+                        elif resource["_modelType"] == "folder":
+                            self.gc.downloadFolderRecursive(resource["_id"], temp_dir)
+
+        # Write the environment.json to the r2d context directory
+        with open(os.path.join(temp_dir, "environment.json"), "w") as fp:
+            json.dump(
+                {
+                    "config": {
+                        "buildpack": self.container_config.buildpack,
+                        "environment": self.container_config.environment,
+                        "user": self.container_config.container_user,
+                    }
+                },
+                fp,
+            )
+        return temp_dir
+
+    def get_tag(self, force=False):
+        """Compute a unique docker image tag.
+
+        Tag is created as combination of 1) checksum of repo2docker files (apt.txt, etc)
+        and the tale/image environment file, 2) checksum of Dockerfile created by r2d
+        using files from 1).
+        """
+        env_hash = hashlib.md5("Environment checksum".encode())
+        for fname in os.listdir(self.build_context):
+            env_hash.update(fname.encode())
+            with open(os.path.join(self.build_context, fname), "rb") as fp:
+                env_hash.update(fp.read())
+        if force and self.tale["_id"]:
+            env_hash.update(self.tale["_id"].encode())
+
+        # Perform dry run to get the Dockerfile's checksum
+        registry_netloc = urlparse(DEPLOYMENT.registry_url).netloc
+        ret, output_digest = self.run_r2d(
+            f"{registry_netloc}/placeholder_env/placeholder_dockerfile",
+            self.build_context,
+            dry_run=True,
+        )
+
+        # Remove the temporary directory, cause we want entire workspace for build
+        # NOTE: or maybe not? That would avoid bloating image with things we override anyway
+        # shutil.rmtree(self.build_context, ignore_errors=True)
+
+        return f"{registry_netloc}/tale/{env_hash.hexdigest()}:{output_digest}"
+
+    def run_r2d(
+        self,
+        tag,
+        build_dir,
+        extra_volume=None,
+        dry_run=False,
+    ):
+        """
+        Run repo2docker on the workspace using a shared temp directory. Note that
+        this uses the "local" provider.  Use the same default user-id and
+        user-name as BinderHub
+        """
+
+        # Extra arguments for r2d
+        extra_args = ''
+        if self.container_config.buildpack == "MatlabBuildPack":
+            extra_args = ' --build-arg FILE_INSTALLATION_KEY={} '.format(
+                os.environ.get("MATLAB_FILE_INSTALLATION_KEY")
+            )
+        elif self.container_config.buildpack == "StataBuildPack":
+            # License is also needed at build time but can't easily
+            # be mounted. Pass it as a build arg
+
+            source_path = _get_stata_license_path()
+            with open("/host/" + source_path, "r") as license_file:
+                stata_license = license_file.read()
+                encoded = base64.b64encode(stata_license.encode("ascii")).decode("ascii")
+                extra_args = " --build-arg STATA_LICENSE_ENCODED='{}' ".format(encoded)
+
+        op = "--no-build" if dry_run else "--no-run"
+        r2d_cmd = (
+            "jupyter-repo2docker "
+            "--config='/wholetale/repo2docker_config.py' "
+            "--target-repo-dir='/home/jovyan/work/workspace' "
+            f"--user-id=1000 --user-name={self.container_config.container_user} "
+            f"--no-clean {op} --debug {extra_args} "
+            f"--image-name {tag} {build_dir}"
+        )
+
+        logging.info('Calling %s', r2d_cmd)
+
+        volumes = {
+            '/var/run/docker.sock': {
+                'bind': '/var/run/docker.sock', 'mode': 'rw'
+            },
+            '/tmp': {
+                'bind': '/host/tmp', 'mode': 'ro'
+            }
+        }
+
+        if extra_volume is not None:
+            volumes.update(extra_volume)
+
+        container = self.dh.cli.containers.run(
+            image=self.container_config.repo2docker_version,
+            command=r2d_cmd,
+            environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
+            privileged=True,
+            detach=True,
+            remove=True,
+            volumes=volumes
+        )
+
+        # Job output must come from stdout/stderr
+        h = hashlib.md5("R2D output".encode())
+        for line in container.logs(stream=True):
+            output = line.decode("utf-8").strip()
+            if not output.startswith("Using local repo"):  # contains variable path
+                h.update(output.encode("utf-8"))
+            if not dry_run:  # We don't want to see it.
+                print(output)
+
+        ret = container.wait()
+        if ret["StatusCode"] != 0:
+            logging.error("Error building image")
+        else:
+            logging.error("Should push image")
+        # Since detach=True, then we need to explicitly check for the
+        # container exit code
+        return ret, h.hexdigest()
+
+    def __del__(self):
+        if self._build_context is not None:
+            shutil.rmtree(self._build_context, ignore_errors=True)

--- a/gwvolman/build_utils.py
+++ b/gwvolman/build_utils.py
@@ -210,8 +210,6 @@ class ImageBuilder:
         ret = container.wait()
         if ret["StatusCode"] != 0:
             logging.error("Error building image")
-        else:
-            logging.error("Should push image")
         # Since detach=True, then we need to explicitly check for the
         # container exit code
         return ret, h.hexdigest()

--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -46,6 +46,30 @@ RUN_WT_BUTTON_IMG = (
 )
 
 
+# NOTE: changing order of ENV_FILES will result in cache invalidation.
+# You have been warned.
+R2D_FILENAMES = (
+    "environment.yml",
+    "Pipfile",
+    "Pipfile.lock",
+    "requirements.txt",
+    "setup.py",
+    "Project.toml",
+    "REQUIRE",
+    "install.R",
+    "apt.txt",
+    "DESCRIPTION",
+    "postBuild",
+    "start",
+    "runtime.txt",
+    "default.nix",
+    "install.do",
+    "JuliaProject.toml",
+    "requirements3.txt",
+    "toolboxes.txt",
+    "Dockerfile",
+)
+
 class InstanceStatus(object):
     LAUNCHING = 0
     RUNNING = 1

--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -313,6 +313,11 @@ class DataONEPublishProvider(PublishProvider):
             res_map = metadata.resource_map.serialize()
             # Update the resource map with citations
             # Turn the resource map into readable bytes
+            try:
+                res_map = res_map.encode()
+            except AttributeError:
+                pass
+
             res_meta = metadata.generate_system_metadata(
                 pid=res_pid,
                 name=str(),

--- a/gwvolman/tests/test_build_image.py
+++ b/gwvolman/tests/test_build_image.py
@@ -1,30 +1,23 @@
+import base64
 from girder_client import GirderClient
-from docker import DockerClient, APIClient
-from gwvolman.utils import ContainerConfig
 import mock
-import girder_worker
 import os
-
-from gwvolman.tasks import build_tale_image
-
-
-class MockVolume:
-    @property
-    def id(self):
-        return "abc"
-
-    def remove(self):
-        return True
+import pytest
+import docker
 
 
 def mock_gc_get(path, parameters=None):
+    workspace1_root = "/collection/WTworkspace/WTworkspaces/tale1"
     if path.startswith("/image"):
         env = os.path.basename(path)
         if env not in {"jupyter", "stata", "matlab"}:
             raise ValueError(f"Unknown image '{env}'")
         return {
             "_id": env,
-            "config": {"buildpack": f"{env.capitalize()}BuildPack", "user": "jovyan"},
+            "config": {
+                "buildpack": f"{env.capitalize()}BuildPack",
+                "user": "jovyan",
+            },
         }
     elif path in ("/folder/workspace1"):
         return {
@@ -44,147 +37,314 @@ def mock_gc_get(path, parameters=None):
                     "last_build": 1,
                     "imageId": images[tale_id],
                     "repo2docker_version": "wholetale/r2d_wt",
-                }
+                },
             }
         except KeyError:
             raise ValueError(f"Unknown tale '{tale_id}'")
     elif path in ("/user/me"):
         return {"login": "user1"}
+    elif path == "/resource/workspace1/path":
+        return workspace1_root
+    elif path == "/resource/lookup":
+        if parameters["path"] == os.path.join(workspace1_root, "some_file.txt"):
+            return {"_id": "some_file_id", "_modelType": "item"}
+        if parameters["path"] == os.path.join(workspace1_root, "some_folder"):
+            return {"_id": "some_folder_id", "_modelType": "folder"}
 
 
-CONTAINER_CONFIG = ContainerConfig(
-    buildpack="JupyterBuildPack",
-    repo2docker_version="wholetale/repo2docker_wholetale:latest",
-    image="image1",
-    command="test",
-    mem_limit=2,
-    cpu_shares=1,
-    container_port=8080,
-    container_user="jovyan",
-    target_mount="/work",
-    url_path="",
-    environment=[],
-    csp=""
-)
-
-JUPYTER_R2D_CALL = mock.call(
-    image='wholetale/repo2docker_wholetale:latest',
-    command="jupyter-repo2docker --config='/wholetale/repo2docker_config.py'"
-            " --target-repo-dir='/home/jovyan/work/workspace'"
-            " --user-id=1000 --user-name=jovyan --no-clean --no-run --debug"
-            "  --image-name registry.test.wholetale.org/tale1/1624994605 /tmp/xxx",
-    environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
-    privileged=True,
-    detach=True,
-    remove=True,
-    volumes={
-        '/var/run/docker.sock': {
-            'bind': '/var/run/docker.sock',
-            'mode': 'rw'
-        },
-        '/tmp': {
-            'bind': '/host/tmp',
-            'mode': 'ro'
+def mock_gc_listItem(folderId, name=None):
+    if folderId == "workspace1":
+        content = {
+            "apt.txt": {"_id": "apt_id", "name": "apt.txt"},
+            "install.do": {"_id": "stata_id", "name": "install.do"},
+            "toolboxes.txt": {"_id": "matlab_id", "name": "toolboxes.txt"},
         }
+        try:
+            yield from [content[name]]
+        except KeyError:
+            yield from []
+
+
+def mock_gc_downloadItem(itemId, target):
+    files = {
+        "apt_id": ("apt.txt", "vim"),
+        "stata_id": ("install.do", "some_stata_package"),
+        "matlab_id": ("toolboxes.txt", "some_matlab_environment"),
+        "some_file_id": ("some_file.txt", "some_content"),
     }
-)
-
-STATA_R2D_CALL = mock.call(
-    image='wholetale/repo2docker_wholetale:latest',
-    command="jupyter-repo2docker --config='/wholetale/repo2docker_config.py'"
-            " --target-repo-dir='/home/jovyan/work/workspace'"
-            " --user-id=1000 --user-name=jovyan --no-clean --no-run --debug"
-            "  --build-arg STATA_LICENSE_ENCODED='dGhpcyBpcyBhIGZha2Ugc3RhdGEgbGljZW5zZQo='"
-            "  --image-name registry.test.wholetale.org/tale2/1624994605 /tmp/xxx",
-    environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
-    privileged=True,
-    detach=True,
-    remove=True,
-    volumes={
-        '/var/run/docker.sock': {
-            'bind': '/var/run/docker.sock',
-            'mode': 'rw'
-        },
-        '/tmp': {
-            'bind': '/host/tmp',
-            'mode': 'ro'
-        }
-    }
-)
-
-MATLAB_R2D_CALL = mock.call(
-    image='wholetale/repo2docker_wholetale:latest',
-    command="jupyter-repo2docker --config='/wholetale/repo2docker_config.py'"
-            " --target-repo-dir='/home/jovyan/work/workspace'"
-            " --user-id=1000 --user-name=jovyan --no-clean --no-run --debug"
-            "  --build-arg FILE_INSTALLATION_KEY=fake-matlab-key"
-            "  --image-name registry.test.wholetale.org/tale3/1624994605 /tmp/xxx",
-    environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
-    privileged=True,
-    detach=True,
-    remove=True,
-    volumes={
-        '/var/run/docker.sock': {
-            'bind': '/var/run/docker.sock',
-            'mode': 'rw'
-        },
-        '/tmp': {
-            'bind': '/host/tmp',
-            'mode': 'ro'
-        }
-    }
-)
+    fname, content = files[itemId]
+    with open(os.path.join(target, fname), "w") as fp:
+        fp.write(content)
 
 
-@mock.patch.dict(os.environ, {"MATLAB_FILE_INSTALLATION_KEY": "fake-matlab-key"})
-@mock.patch("base64.b64encode", return_value=bytes("dGhpcyBpcyBhIGZha2Ugc3RhdGEgbGljZW5zZQo=",
-            encoding='ascii'))
-@mock.patch("time.time", return_value=1624994605)
+def mock_gc_downloadFolderRecursive(folderId, target):
+    if folderId == "some_folder_id":
+        os.makedirs(os.path.join(target, "some_folder"))
+        with open(os.path.join(target, "some_folder", "other_file"), "w") as fp:
+            fp.write("Other build file content\n")
+    elif folderId == "workspace1":
+        for obj_id in ("apt_id", "stata_id", "matlab_id", "some_file_id"):
+            mock_gc_downloadItem(obj_id, target)
+        mock_gc_downloadFolderRecursive("some_folder_id", target)
+    else:
+        raise ValueError
+
+
+def docker_services_get(service_name):
+    class MockService:
+        def __init__(self, name):
+            namespace, service = name.split("_")
+            self.namespace = namespace
+            self.service = service
+
+        @property
+        def attrs(self):
+            rule = f"Host(`{self.service}.dev.wholetale.org`)"
+            return {
+                "Spec": {
+                    "Labels": {
+                        "com.docker.stack.namespace": self.namespace,
+                        f"traefik.http.routers.{self.service}.rule": rule,
+                    }
+                }
+            }
+
+    return MockService(service_name)
+
+
+def docker_run_r2d_container(**kwargs):
+    class MockContainer:
+        @staticmethod
+        def logs(stream=False):
+            yield b"First line of Dockerfile"
+            yield b"Second line of Dockerfile"
+
+        @staticmethod
+        def wait():
+            return {"StatusCode": 0}
+
+    return MockContainer()
+
+
+@mock.patch.dict(os.environ, {"HOSTDIR": "/"})
 @mock.patch("docker.APIClient")
-@mock.patch("builtins.open", new_callable=mock.mock_open(), read_data=bytes("blah",
-            encoding="ascii"))
-@mock.patch("tempfile.mkdtemp", return_value="/tmp/xxx")
-@mock.patch("docker.DockerClient.containers")
-@mock.patch("docker.DockerClient.images")
-@mock.patch("docker.DockerClient.login")
-@mock.patch("shutil.rmtree", return_value=True)
-@mock.patch("gwvolman.tasks._get_container_config", return_value=CONTAINER_CONFIG)
-def test_build_tale_image(gcc, sh, dcl, dci, containers, tf, op, ac, time, b64):
+@mock.patch(
+    "gwvolman.utils.Deployment.registry_url",
+    new_callable=mock.PropertyMock,
+    return_value="https://registry.dev.wholetale.org",
+)
+def test_image_builder(depl, dapicli):
+    gc = mock.MagicMock(spec=GirderClient)
+    gc.get = mock_gc_get
+    gc.listItem = mock_gc_listItem
+    gc.downloadItem = mock_gc_downloadItem
+    gc.downloadFolderRecursive = mock_gc_downloadFolderRecursive
+    tale = {
+        "imageId": "jupyter",
+        "workspaceId": "workspace1",
+        "_id": "tale1",
+        "config": {"extra_build_files": ["some_file.txt", "some_folder"]},
+    }
+    with mock.patch("docker.from_env") as dcli:
+        dcli.return_value.containers.run = docker_run_r2d_container
+        dcli.return_value.services.get = docker_services_get
 
-    mock_gc = mock.MagicMock(spec=GirderClient)
-    mock_gc.get = mock_gc_get
-    mock_gc.downloadFolderRecursive.return_value = True
+        from gwvolman.build_utils import ImageBuilder
 
-    build_tale_image.girder_client = mock_gc
-    build_tale_image.cli = mock.MagicMock(spec=DockerClient)
-    build_tale_image.cli.images.pull.return_value = True
-    build_tale_image.apicli = mock.MagicMock(spec=APIClient)
+        with pytest.raises(ValueError) as ex:
+            image_builder = ImageBuilder(gc)
+        assert ex.match("Only one of 'imageId' and 'tale' can be set")
+
+        with pytest.raises(ValueError) as ex:
+            image_builder = ImageBuilder(gc, tale=tale, imageId="jupyter")
+        assert ex.match("Only one of 'imageId' and 'tale' can be set")
+
+        image_builder = ImageBuilder(gc, imageId="jupyter")
+        assert image_builder.tale["imageId"] == "jupyter"
+
+        image_builder = ImageBuilder(gc, tale=tale)
+        tag = image_builder.get_tag()
+        assert tag == (
+            "registry.dev.wholetale.org/tale/"
+            "44056037e7d42cdc02490b8f1ffa5446:8c55f2934afafe894125ab12b1d8943c"
+        )
+        tag = image_builder.get_tag(force=True)
+        assert tag == (
+            "registry.dev.wholetale.org/tale/"
+            "8001f2ae1f45be76dc9a6c2f4c708eab:8c55f2934afafe894125ab12b1d8943c"
+        )
+        tale["config"]["extra_build_files"] = ["**"]
+        image_builder = ImageBuilder(gc, tale=tale)
+        tag = image_builder.get_tag()
+        assert tag == (
+            "registry.dev.wholetale.org/tale/"
+            "44056037e7d42cdc02490b8f1ffa5446:8c55f2934afafe894125ab12b1d8943c"
+        )
+
+
+@mock.patch.dict(
+    os.environ, {"HOSTDIR": "/", "MATLAB_FILE_INSTALLATION_KEY": "fake-key"}
+)
+@mock.patch("docker.APIClient")
+@mock.patch(
+    "gwvolman.utils.Deployment.registry_url",
+    new_callable=mock.PropertyMock,
+    return_value="https://registry.dev.wholetale.org",
+)
+def test_r2d_calls(depl, dapicli):
+    gc = mock.MagicMock(spec=GirderClient)
+    gc.get = mock_gc_get
+    gc.listItem = mock_gc_listItem
+    gc.downloadItem = mock_gc_downloadItem
+    gc.downloadFolderRecursive = mock_gc_downloadFolderRecursive
+    tale = {
+        "imageId": "jupyter",
+        "workspaceId": "workspace1",
+        "_id": "tale1",
+        "config": {"extra_build_files": ["some_file.txt", "some_folder"]},
+    }
+
+    from gwvolman.build_utils import ImageBuilder
+
+    with mock.patch("docker.from_env") as dcli:
+        dcli.return_value.images.pull.side_effect = docker.errors.NotFound("blah")
+        image_builder = ImageBuilder(gc, tale=tale)
+        with pytest.raises(ValueError) as ex:
+            image_builder.pull_r2d()
+        assert ex.match(
+            "Requested r2d image 'wholetale/repo2docker_wholetale:latest' not found."
+        )
+
+    with mock.patch("docker.from_env") as dcli:
+        mock_container_run = mock.MagicMock(wraps=docker_run_r2d_container)
+        dcli.return_value.containers.run = mock_container_run
+        dcli.return_value.services.get = docker_services_get
+
+        # Stata
+        tale["imageId"] = "stata"
+        image_builder = ImageBuilder(gc, tale=tale)
+        stata_expected_call = mock.call(
+            image="wholetale/repo2docker_wholetale:latest",
+            command="jupyter-repo2docker --config='/wholetale/repo2docker_config.py'"
+            " --target-repo-dir='/home/jovyan/work/workspace'"
+            " --user-id=1000 --user-name=jovyan --no-clean --no-run --debug"
+            f"  --build-arg STATA_LICENSE_ENCODED='{base64.b64encode(b'blah').decode()}'"
+            f"  --image-name some_tag {image_builder.build_context}",
+            environment=["DOCKER_HOST=unix:///var/run/docker.sock"],
+            privileged=True,
+            detach=True,
+            remove=True,
+            volumes={
+                "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},
+                "/tmp": {"bind": "/host/tmp", "mode": "ro"},
+            },
+        )
+
+        mock_open = mock.mock_open(read_data="blah")
+        with mock.patch("builtins.open", mock_open):
+            ret, _ = image_builder.run_r2d("some_tag", image_builder.build_context)
+        mock_container_run.assert_has_calls([stata_expected_call])
+
+        # Matlab
+        tale["imageId"] = "matlab"
+        image_builder = ImageBuilder(gc, tale=tale)
+        matlab_expected_call = mock.call(
+            image="wholetale/repo2docker_wholetale:latest",
+            command="jupyter-repo2docker --config='/wholetale/repo2docker_config.py'"
+            " --target-repo-dir='/home/jovyan/work/workspace'"
+            " --user-id=1000 --user-name=jovyan --no-clean --no-run --debug"
+            "  --build-arg FILE_INSTALLATION_KEY=fake-key"
+            f"  --image-name some_tag {image_builder.build_context}",
+            environment=["DOCKER_HOST=unix:///var/run/docker.sock"],
+            privileged=True,
+            detach=True,
+            remove=True,
+            volumes={
+                "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},
+                "/tmp": {"bind": "/host/tmp", "mode": "ro"},
+                "/ala": {"bind": "/ala", "mode": "rw"},
+            },
+        )
+        ret, _ = image_builder.run_r2d(
+            "some_tag",
+            image_builder.build_context,
+            extra_volume={"/ala": {"bind": "/ala", "mode": "rw"}},
+        )
+        mock_container_run.assert_has_calls([matlab_expected_call])
+
+
+@mock.patch(
+    "gwvolman.utils.Deployment.registry_url",
+    new_callable=mock.PropertyMock,
+    return_value="https://registry.dev.wholetale.org",
+)
+def test_build_image_task(deployment):
+    from gwvolman.tasks import build_tale_image
+    from gwvolman.constants import TaleStatus
+
+    gc = mock.MagicMock(spec=GirderClient)
+    # gc.get = mock_gc_get
+    tale = {
+        "imageId": "jupyter",
+        "workspaceId": "workspace1",
+        "_id": "tale1",
+        "config": {"extra_build_files": ["some_file.txt", "some_folder"]},
+    }
     build_tale_image.job_manager = mock.MagicMock()
-    girder_worker.task.Task.canceled = mock.PropertyMock(return_value=False)
 
-    containers.run.return_value.wait.return_value = {"StatusCode": 0}
+    # Test building on Tale in Error state
+    gc.get.side_effect = [
+        {"_id": "id", "status": TaleStatus.PREPARING},
+        {"_id": "id", "status": TaleStatus.ERROR},
+    ]
+    build_tale_image.girder_client = gc
+    with pytest.raises(ValueError) as ex:
+        build_tale_image(tale["_id"], force=False)
+    assert ex.match("Cannot build image for a Tale in error state.")
 
-    try:
-        with mock.patch("gwvolman.utils.Deployment.registry_url",
-                        new_callable=mock.PropertyMock) as mock_dep:
+    # Test timeout
+    gc.get.side_effect = [
+        {"_id": "id", "status": TaleStatus.PREPARING},
+        {"_id": "id", "status": TaleStatus.PREPARING},
+    ]
+    with mock.patch("time.time") as fake_time:
+        fake_time.side_effect = [1, 999]
+        with pytest.raises(ValueError) as ex:
+            build_tale_image(tale["_id"], force=False)
+        assert ex.match("Cannot build image. Tale preparing for more than 5 minutes.")
 
-            mock_dep.return_value = "https://registry.test.wholetale.org"
+    with mock.patch("gwvolman.tasks.ImageBuilder") as image_builder:
+        gc.get.side_effect = [
+            {"_id": "id", "status": TaleStatus.READY, "imageInfo": {}},
+        ]
+        build_tale_image.girder_client = gc
+        image_builder.return_value.get_tag.return_value = "some_tag"
+        image_builder.return_value.dh.apicli.inspect_distribution.return_value = {
+            "Descriptor": {"digest": "some_digest"}
+        }
 
-            build_tale_image("tale1", force=False)
-            build_tale_image("tale2", force=False)
-            build_tale_image("tale3", force=False)
+        result = build_tale_image(tale["_id"], force=False)
+        assert result["image_digest"] == "some_tag@some_digest"
+        image_builder.return_value.run_r2d.assert_not_called()
 
-    except ValueError:
-        assert False
+        image_builder.return_value.run_r2d.return_value = ({"StatusCode": 1}, 0)
+        gc.get = mock_gc_get
+        image_builder.return_value.dh.apicli.inspect_distribution.side_effect = [
+            docker.errors.NotFound("No image")
+        ]
+        with pytest.raises(ValueError) as ex:
+            result = build_tale_image(tale["_id"], force=False)
+        image_builder.return_value.run_r2d.assert_called()
+        assert ex.match("Error building tale tale1")
 
-    containers.run.assert_has_calls(
-        [JUPYTER_R2D_CALL, mock.call().logs(stream=True),
-         mock.call().logs().__iter__(), mock.call().wait()])
+        image_builder.return_value.run_r2d.return_value = ({"StatusCode": 0}, 0)
+        image_builder.return_value.dh.apicli.inspect_distribution.side_effect = [
+            docker.errors.NotFound("No image")
+        ]
+        image = mock.MagicMock()
+        image_builder.return_value.dh.cli.images.get.return_value = image
+        image.attrs = {"RepoDigests": ["registry.dev.wholetale.org/foo:tag"]}
 
-    containers.run.assert_has_calls(
-        [STATA_R2D_CALL, mock.call().logs(stream=True),
-         mock.call().logs().__iter__(), mock.call().wait()])
-
-    containers.run.assert_has_calls(
-        [MATLAB_R2D_CALL, mock.call().logs(stream=True),
-         mock.call().logs().__iter__(), mock.call().wait()])
+        result = build_tale_image(tale["_id"], force=False)
+        image_builder.return_value.run_r2d.assert_called()
+        assert result["image_digest"] == "registry.dev.wholetale.org/foo:tag"

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -5,6 +5,7 @@
 """A set of helper routines for WT related tasks."""
 
 from collections import namedtuple
+import hashlib
 import os
 import random
 import re
@@ -27,7 +28,7 @@ REGISTRY_USER = os.environ.get('REGISTRY_USER', 'fido')
 REGISTRY_PASS = os.environ.get('REGISTRY_PASS')
 MOUNTS = {}
 RETRIES = 5
-container_name_pattern = re.compile('tmp\.([^.]+)\.(.+)\Z')
+container_name_pattern = re.compile(r'tmp\.([^.]+)\.(.+)\Z')
 
 PooledContainer = namedtuple('PooledContainer', ['id', 'path', 'host'])
 ContainerConfig = namedtuple('ContainerConfig', [
@@ -37,7 +38,7 @@ ContainerConfig = namedtuple('ContainerConfig', [
     'url_path', 'environment', 'csp'
 ])
 
-SIZE_NOTATION_RE = re.compile("^(\d+)([kmg]?b?)$", re.IGNORECASE)
+SIZE_NOTATION_RE = re.compile(r"^(\d+)([kmg]?b?)$", re.IGNORECASE)
 SIZE_TABLE = {
     '': 1, 'b': 1,
     'k': 1024, 'kb': 1024,
@@ -114,7 +115,7 @@ class Deployment(object):
             ns = service.attrs['Spec']['Labels']['com.docker.stack.namespace']
             router = service_name.replace('%s_' % ns,  '')
             rule = service.attrs['Spec']['Labels']['traefik.http.routers.%s.rule' % router]
-            host =  re.search(r'Host\(`(.+)`\)', rule).group(1)
+            host = re.search(r'Host\(`(.+)`\)', rule).group(1)
             return 'https://' + host
         except docker.errors.APIError:
             return '{}://{}.{}'.format("https", service_name[3:], DOMAIN)
@@ -164,19 +165,18 @@ def _get_user_and_instance(girder_client, instanceId):
     return user, instance
 
 
-
 def _get_container_config(gc, tale):
     if tale is None:
         container_config = {}  # settings['container_config']
     else:
         image = gc.get('/image/%s' % tale['imageId'])
         tale_config = image['config'] or {}
-        if tale['config']:
+        if tale.get('config'):
             tale_config.update(tale['config'])
 
         image_info = tale.get("imageInfo", {})
         digest = image_info.get("digest")
-        repo2docker_version = tale_config.get("repo2docker_version", REPO2DOCKER_VERSION)
+        repo2docker_version = image_info.get("repo2docker_version", REPO2DOCKER_VERSION)
 
         try:
             mem_limit = size_notation_to_bytes(tale_config.get('memLimit', '2g'))
@@ -234,9 +234,7 @@ def _launch_container(volumeName, nodeId, container_config, tale_id='', instance
     volumes = _get_container_volumes(source_mount, container_config, MOUNTPOINTS)
     for source in volumes:
         mounts.append(
-                docker.types.Mount(type='bind',
-                    source=source,
-                    target=volumes[source]['bind'])
+            docker.types.Mount(type='bind', source=source, target=volumes[source]['bind'])
         )
 
     host = 'tmp-{}'.format(new_user(12).lower())
@@ -251,18 +249,23 @@ def _launch_container(volumeName, nodeId, container_config, tale_id='', instance
     else:
         csp = "frame-ancestors 'self' {}".format(DEPLOYMENT.dashboard_url)
 
+    traefik_loadbalancer_prefix = f"traefik.http.services.{host}.loadbalancer"
+
     service = cli.services.create(
         container_config.image,
         command=rendered_command,
         labels={
-            'traefik.http.services.%s.loadbalancer.server.port' % host: str(container_config.container_port),
+            f"{traefik_loadbalancer_prefix}.server.port": str(container_config.container_port),
             'traefik.enable': 'true',
             'traefik.http.routers.%s.rule' % host: 'Host(`{}.{}`)'.format(host, DOMAIN),
             'traefik.http.routers.%s.entrypoints' % host: TRAEFIK_ENTRYPOINT,
             'traefik.http.routers.%s.tls' % host: 'true',
-            'traefik.http.middlewares.%s-csp.headers.customresponseheaders.Content-Security-Policy' % host: csp,
-            'traefik.http.services.%s.loadbalancer.passhostheader' % host: 'true',
-            'traefik.http.services.%s.loadbalancer.server.port' % host: str(container_config.container_port),
+            (
+                f'traefik.http.middlewares.{host}'
+                '-csp.headers.customresponseheaders.Content-Security-Policy'
+            ): csp,
+            f"{traefik_loadbalancer_prefix}.passhostheader": 'true',
+            f"{traefik_loadbalancer_prefix}.server.port": str(container_config.container_port),
             'traefik.http.routers.%s.middlewares' % host: 'girder, %s-csp' % host,
             'traefik.docker.network': DEPLOYMENT.traefik_network,
             'wholetale.instanceId': instance_id,
@@ -290,7 +293,14 @@ def _launch_container(volumeName, nodeId, container_config, tale_id='', instance
     return service, {'url': url}
 
 
-def _build_image(cli, tale_id, image, tag, build_dir, repo2docker_version, extra_volume=None):
+def _build_image(
+    cli,
+    container_config,
+    tag,
+    build_dir,
+    extra_volume=None,
+    dry_run=False,
+):
     """
     Run repo2docker on the workspace using a shared temp directory. Note that
     this uses the "local" provider.  Use the same default user-id and
@@ -299,10 +309,11 @@ def _build_image(cli, tale_id, image, tag, build_dir, repo2docker_version, extra
 
     # Extra arguments for r2d
     extra_args = ''
-    if image['config']['buildpack'] == "MatlabBuildPack":
+    if container_config.buildpack == "MatlabBuildPack":
         extra_args = ' --build-arg FILE_INSTALLATION_KEY={} '.format(
-                os.environ.get("MATLAB_FILE_INSTALLATION_KEY"))
-    elif image['config']['buildpack'] == "StataBuildPack":
+            os.environ.get("MATLAB_FILE_INSTALLATION_KEY")
+        )
+    elif container_config.buildpack == "StataBuildPack":
         # License is also needed at build time but can't easily
         # be mounted. Pass it as a build arg
 
@@ -312,19 +323,19 @@ def _build_image(cli, tale_id, image, tag, build_dir, repo2docker_version, extra
             encoded = base64.b64encode(stata_license.encode("ascii")).decode("ascii")
             extra_args = " --build-arg STATA_LICENSE_ENCODED='{}' ".format(encoded)
 
-    r2d_cmd = ("jupyter-repo2docker "
-               "--config='/wholetale/repo2docker_config.py' "
-               "--target-repo-dir='/home/jovyan/work/workspace' "
-               "--user-id=1000 --user-name={} "
-               "--no-clean --no-run --debug {} "
-               "--image-name {} {}".format(
-                                           image['config']['user'],
-                                           extra_args,
-                                           tag, build_dir))
+    op = "--no-build" if dry_run else "--no-run"
+    r2d_cmd = (
+        "jupyter-repo2docker "
+        "--config='/wholetale/repo2docker_config.py' "
+        "--target-repo-dir='/home/jovyan/work/workspace' "
+        f"--user-id=1000 --user-name={container_config.container_user} "
+        f"--no-clean {op} --debug {extra_args} "
+        f"--image-name {tag} {build_dir}"
+    )
 
-    logging.info('Calling %s (%s)', r2d_cmd, tale_id)
+    logging.info('Calling %s', r2d_cmd)
 
-    volumes={
+    volumes = {
         '/var/run/docker.sock': {
             'bind': '/var/run/docker.sock', 'mode': 'rw'
         },
@@ -337,7 +348,7 @@ def _build_image(cli, tale_id, image, tag, build_dir, repo2docker_version, extra
         volumes.update(extra_volume)
 
     container = cli.containers.run(
-        image=repo2docker_version,
+        image=container_config.repo2docker_version,
         command=r2d_cmd,
         environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
         privileged=True,
@@ -347,12 +358,18 @@ def _build_image(cli, tale_id, image, tag, build_dir, repo2docker_version, extra
     )
 
     # Job output must come from stdout/stderr
+    h = hashlib.md5("R2D output".encode())
     for line in container.logs(stream=True):
-        print(line.decode('utf-8').strip())
+        output = line.decode("utf-8").strip()
+        if not output.startswith("Using local repo"):  # contains variable path
+            h.update(output.encode("utf-8"))
+        if not dry_run:  # We don't want to see it.
+            print(output)
 
     # Since detach=True, then we need to explicitly check for the
     # container exit code
-    return container.wait()
+    return container.wait(), h.hexdigest()
+
 
 def _get_container_volumes(mountpoint, container_config, directories):
     volumes = {
@@ -408,7 +425,7 @@ def _recorded_run(cli, mountpoint, container_config, tag, entrypoint):
         image=tag,
         command=rpz_cmd,
         environment=['DOCKER_HOST=unix:///var/run/docker.sock'],
-        cap_add = ['SYS_PTRACE'],
+        cap_add=['SYS_PTRACE'],
         detach=True,
         remove=True,
         volumes=volumes
@@ -447,6 +464,7 @@ def _recorded_run(cli, mountpoint, container_config, tag, entrypoint):
         raise ValueError('Error executing cpr for recorded run')
 
     return ret
+
 
 def _get_stata_license_path():
     license_date = datetime.date.today() + rel.relativedelta(days=1, weekday=rel.SU)


### PR DESCRIPTION
Tag Tale images using the checksum of r2d files and r2d short_id. Then during `build_image` phase check if given image exists in the local registry. This allows for more efficient caching even for completely new tales.

### How to test?
1. Create a Tale. Run it. Shut it down.
1. Upload a file "hello.txt" (or anything not r2d related) to the workspace. Run the tale.
1. It should skip the build phase.
1. Upload `apt.txt` with any sane content.
1. Run the tale. It should build a new image.
1. Stop and delete the Tale.
1. Create a new Tale, upload the same `apt.txt`, run the tale.
1. It should skip the build phase.