### PR TITLE
Dump docker stats for a RRun

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update -qqy && \
     libcurl4-openssl-dev \
     zlib1g-dev \
     libfuse-dev \
+    moreutils \
     libpython3-dev && \
   apt-get -qqy clean all && \
   echo "user_allow_other" >> /etc/fuse.conf && \


### PR DESCRIPTION
Adds `docker stats` output to run's `workspace/.docker_stats`.

### How to test?
1. Run a RRun
2. Verify that `<run>/workspace/.docker_stats` is created