### PR TITLE
Revert "Avoid hardcoding mountpoint"

### DIFF
--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -227,7 +227,8 @@ def _launch_container(volumeName, nodeId, container_config, tale_id='', instance
     #                        target=container_config.target_mount)
     # ]
 
-    source_mount = cli.volumes.get(volumeName).attrs["Mountpoint"]
+    # FIXME: get mountPoint
+    source_mount = '/var/lib/docker/volumes/{}/_data'.format(volumeName)
     mounts = []
     volumes = _get_container_volumes(source_mount, container_config, MOUNTPOINTS)
     for source in volumes:


### PR DESCRIPTION
Reverts whole-tale/gwvolman#153. This works on a single node, because manager and worker are the same for local deployment... For swarm it fails, cause the volume exists on the worker and we're calling this task from the manager.