### PR TITLE
Avoid hardcoding mountpoint (done right)

### DIFF
--- a/gwvolman/tests/test_volumes.py
+++ b/gwvolman/tests/test_volumes.py
@@ -73,7 +73,8 @@ def test_create_volume(mgfs, mfd, cdv, gs, gak, volumes, info, nu):
             'mountPoint': '/path/to/mountpoint/',
             'volumeName': 'tale1_user1_123456',
             'sessionId': 'session1',
-            'instanceId': 'instance1'
+            'instanceId': 'instance1',
+            'taleId': "tale1",
         }
 
         assert ret == expected


### PR DESCRIPTION
Re-do of #153 . This time I'm doing "the right thing"^{TM} and grab the required information from `create_volume` task's result.