### PR TITLE
Add manifest sha1 files to ignore list

### DIFF
--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -94,8 +94,10 @@ class DataONEPublishProvider(PublishProvider):
         # to upload the files.
         ignore_files = [
             "tagmanifest-sha256.txt",
+            "tagmanifest-sha1.txt",
             "tagmanifest-md5.txt",
             "manifest-sha256.txt",
+            "manifest-sha1.txt",
             "manifest-md5.txt",
             "bag-info.txt",
             "bagit.txt",


### PR DESCRIPTION
Missed this when implementing https://github.com/whole-tale/girder_wholetale/pull/525. 

This PR adds the bagit *manifest-sha1.txt files to the ignore list for publishing to DataONE 