### PR TITLE
Use serialize_to_transport to generate valid EML

### DIFF
--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -312,7 +312,7 @@ class DataONEPublishProvider(PublishProvider):
             metadata.create_resource_map(res_pid, eml_pid, uploaded_pids)
             metadata.set_related_identifiers(manifest, eml_pid, self.tale,
                                                 self.dataone_node,  self.gc)
-            res_map = metadata.resource_map.serialize()
+            res_map = metadata.resource_map.serialize_to_transport()
             # Update the resource map with citations
             # Turn the resource map into readable bytes
             try:


### PR DESCRIPTION
When publishing to D1, the serialized ResourceMap is RDF but needs to be EML. This PR uses the `ResourceMap.serialize_to_transport()` method instead of the `rdflib.graph.ConjunctiveGraph.serialize()`.

See also  the docs for `d1_common.resource_map.ResourceMap` https://dataone-python.readthedocs.io/en/latest/d1_common/api/d1_common.html

**To Test**:
* Requires https://github.com/whole-tale/girder_wholetale/pull/528
* Create and publish a Tale as described in https://github.com/whole-tale/girder_wholetale/pull/528