### PR TITLE
Prevent 'double' publish of the same version of a Tale

### DIFF
--- a/gwvolman/lib/dataone/publish.py
+++ b/gwvolman/lib/dataone/publish.py
@@ -6,7 +6,6 @@ import jwt
 import logging
 import mimetypes
 import os
-from pathlib import Path
 import sys
 import tempfile
 from typing import Tuple, Union
@@ -296,6 +295,7 @@ class DataONEPublishProvider(PublishProvider):
                 "repository_id": res_pid,
                 "uri": package_url,
                 "date": datetime.datetime.utcnow().isoformat(),
+                "versionId": self.version_id,
             }
 
             if self.published:

--- a/gwvolman/lib/zenodo.py
+++ b/gwvolman/lib/zenodo.py
@@ -379,6 +379,7 @@ class ZenodoPublishProvider(PublishProvider):
             "date": datetime.datetime.utcnow().isoformat(),
             "repository_id": str(deposition["id"]),
             "repository": self.resource_server,
+            "versionId": self.version_id,
         }
         if self.published:
             self.tale["publishInfo"][self._published_info_index].update(publish_info)

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -431,6 +431,8 @@ def publish(self,
     else:
         raise ValueError("Unsupported publisher ({})".format(token["provider"]))
 
+    if provider.published and provider.publication_info.get("versionId") == version_id:
+        raise ValueError(f"This version of the Tale ({version_id}) has already been published.")
     provider.publish()
 
 


### PR DESCRIPTION
This PR partially addresses https://github.com/whole-tale/whole-tale/issues/117. It's not meant as a comprehensive solution and as-is it's very easy to circumvent (switch between versions, re-import, basically anything that change `versionId`). However, it excels at preventing the most common "mis-use" of publish in WT: user double clicking 'publish' in the publication modal or repeated attempt of publishing the same Tale without any modifications...

### How to test?
1. Create a Tale.
2. Publish it to DataONE or Zenodo. Operation should work
3. Repeat 2. (using the same provider). Operation should fail.