### PR TITLE
Drop container name from stats

### DIFF
--- a/gwvolman/tests/test_recorded_run.py
+++ b/gwvolman/tests/test_recorded_run.py
@@ -148,7 +148,7 @@ def test_recorded_run(
                     "/host/usr/bin/docker",
                     "stats",
                     "--format",
-                    '"{{.Name}},{{.CPUPerc}},{{.MemUsage}},{{.NetIO}},{{.BlockIO}},{{.PIDs}}"',
+                    '"{{.CPUPerc}},{{.MemUsage}},{{.NetIO}},{{.BlockIO}},{{.PIDs}}"',
                     "container_id",
                 ],
                 stdout=-1,

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -342,7 +342,7 @@ def _recorded_run(cli, mountpoint, container_config, tag, entrypoint):
         HOSTDIR + "/usr/bin/docker",
         "stats",
         "--format",
-        '"{{.Name}},{{.CPUPerc}},{{.MemUsage}},{{.NetIO}},{{.BlockIO}},{{.PIDs}}"',
+        '"{{.CPUPerc}},{{.MemUsage}},{{.NetIO}},{{.BlockIO}},{{.PIDs}}"',
         container.id
     ]
     workspace_path = os.path.join(HOSTDIR + mountpoint, "workspace")


### PR DESCRIPTION
Super minor, but the container name seems meaningless in this context.  