### PR TITLE
Pull image before recorded run

### DIFF
--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -331,6 +331,8 @@ def _recorded_run(cli, mountpoint, container_config, tag, entrypoint):
     print("Running Tale with command: " + run_cmd)
     print("Running image: " + tag)
 
+    cli.images.pull(tag)
+
     container = cli.containers.create(
         image=tag,
         command=run_cmd,


### PR DESCRIPTION
**Problem**:
`containers.create()` does not pull the image. It is possible to start a recorded run on a node where the image does not already exist or before it is built.

**Test**:
* TBD