### PR TITLE
Make image build and rrun cancelable

### DIFF
--- a/gwvolman/build_utils.py
+++ b/gwvolman/build_utils.py
@@ -10,7 +10,13 @@ import tempfile
 from urllib.parse import urlparse
 
 from .constants import R2D_FILENAMES
-from .utils import _get_container_config, DEPLOYMENT, _get_stata_license_path
+from .utils import (
+    _get_container_config,
+    DEPLOYMENT,
+    _get_stata_license_path,
+    DummyTask,
+    stop_container
+)
 
 
 class DockerHelper:
@@ -155,17 +161,14 @@ class ImageBuilder:
 
         return f"{registry_netloc}/tale/{env_hash.hexdigest()}:{output_digest}"
 
-    def run_r2d(
-        self,
-        tag,
-        build_dir,
-        dry_run=False,
-    ):
+    def run_r2d(self, tag, build_dir, dry_run=False, task=None):
         """
         Run repo2docker on the workspace using a shared temp directory. Note that
         this uses the "local" provider.  Use the same default user-id and
         user-name as BinderHub
         """
+
+        task = task or DummyTask
 
         # Extra arguments for r2d
         extra_args = ""
@@ -222,13 +225,20 @@ class ImageBuilder:
         # Job output must come from stdout/stderr
         h = hashlib.md5("R2D output".encode())
         for line in container.logs(stream=True):
+            if task.canceled:
+                stop_container(container)
+                break
             output = line.decode("utf-8").strip()
             if not output.startswith("Using local repo"):  # contains variable path
                 h.update(output.encode("utf-8"))
             if not dry_run:  # We don't want to see it.
                 print(output)
 
-        ret = container.wait()
+        try:
+            ret = container.wait()
+        except docker.errors.NotFound:
+            ret = {"StatusCode": -123}
+
         if ret["StatusCode"] != 0:
             logging.error("Error building image")
         # Since detach=True, then we need to explicitly check for the

--- a/gwvolman/build_utils.py
+++ b/gwvolman/build_utils.py
@@ -226,6 +226,7 @@ class ImageBuilder:
         h = hashlib.md5("R2D output".encode())
         for line in container.logs(stream=True):
             if task.canceled:
+                task.request.chain = None
                 stop_container(container)
                 break
             output = line.decode("utf-8").strip()

--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -92,4 +92,4 @@ class RunStatus(object):
     RUNNING = 2
     COMPLETED = 3
     FAILED = 4
-    CANCELLED = 5
+    CANCELED = 5

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -358,6 +358,7 @@ def build_tale_image(task, tale_id, force=False):
     # temp_dir = tempfile.mkdtemp(dir=HOSTDIR + "/tmp")
     ret, _ = image_builder.run_r2d(tag, image_builder.build_context, task=task)
     if task.canceled:
+        task.request.chain = None
         logging.info("Build canceled.")
         return
 

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -356,9 +356,12 @@ def build_tale_image(task, tale_id, force=False):
 
     # Prepare build context
     # temp_dir = tempfile.mkdtemp(dir=HOSTDIR + "/tmp")
-    ret, _ = image_builder.run_r2d(tag, image_builder.build_context)
+    ret, _ = image_builder.run_r2d(tag, image_builder.build_context, task=task)
+    if task.canceled:
+        logging.info("Build canceled.")
+        return
 
-    if ret['StatusCode'] != 0:
+    if ret["StatusCode"] != 0:
         # repo2docker build failed
         raise ValueError('Error building tale {}'.format(tale_id))
 
@@ -700,6 +703,7 @@ def _write_env_json(workspace_dir, image):
 def recorded_run(self, run_id, tale_id, entrypoint):
     """Start a recorded run for a tale version"""
     run = self.girder_client.get(f"/run/{run_id}")
+    state = RecordedRunCleaner(run, self.girder_client)
     tale = self.girder_client.get(
         f"/tale/{tale_id}/restore", parameters={"versionId": run["runVersionId"]}
     )
@@ -721,6 +725,7 @@ def recorded_run(self, run_id, tale_id, entrypoint):
     # Create Docker volume
     vol_name = "%s_%s_%s" % (run_id, user['login'], new_user(6))
     mountpoint = _create_docker_volume(image_builder.dh.cli, vol_name)
+    state.volume_created = image_builder.dh.cli.volumes.get(vol_name)
 
     # Create fuse directories
     _make_fuse_dirs(mountpoint, ['data', 'workspace'])
@@ -728,9 +733,12 @@ def recorded_run(self, run_id, tale_id, entrypoint):
     # Mount data and workspace for the run
     api_key = _get_api_key(self.girder_client)
     session = _get_session(self.girder_client, version_id=run['runVersionId'])
+    state.session_created = session["_id"]
+
     if session['_id'] is not None:
         _mount_girderfs(mountpoint, 'data', 'wt_dms', session['_id'], api_key, hostns=True)
     _mount_bind(mountpoint, "run", {"runId": run["_id"], "taleId": tale["_id"]})
+    state.fs_mounted = mountpoint
 
     # Build the image for the run
     self.job_manager.updateProgress(
@@ -746,6 +754,7 @@ def recorded_run(self, run_id, tale_id, entrypoint):
     work_dir = os.path.join(mountpoint, 'workspace')
     image = self.girder_client.get('/image/%s' % tale['imageId'])
     env_json = _write_env_json(work_dir, image)
+    state.env_written = env_json
 
     # Build currently assumes tmp directory, in this case mount the run workspace
     container_config = image_builder.container_config
@@ -754,10 +763,17 @@ def recorded_run(self, run_id, tale_id, entrypoint):
     print(f"Using repo2docker {container_config.repo2docker_version}")
     work_target = os.path.join(container_config.target_mount, 'workspace')
 
+    if self.canceled:
+        state.cleanup()
+        return
+
     try:
         if not image_builder.cached_image(tag):
             print("Building image for recorded run " + tag)
-            ret, _ = image_builder.run_r2d(tag, work_target)
+            ret, _ = image_builder.run_r2d(tag, work_target, task=self)
+            if self.canceled:
+                state.cleanup()
+                return
             if ret['StatusCode'] != 0:
                 raise ValueError('Image build failed for recorded run {}'.format(run_id))
 
@@ -766,7 +782,17 @@ def recorded_run(self, run_id, tale_id, entrypoint):
             current=3, forceFlush=True)
 
         set_run_status(run, RunStatus.RUNNING)
-        _recorded_run(image_builder.dh.cli, mountpoint, container_config, tag, entrypoint)
+        _recorded_run(
+            image_builder.dh.cli,
+            mountpoint,
+            container_config,
+            tag,
+            entrypoint,
+            task=self
+        )
+        if self.canceled:
+            state.cleanup()
+            return
 
         set_run_status(run, RunStatus.COMPLETED)
         self.job_manager.updateProgress(
@@ -776,28 +802,55 @@ def recorded_run(self, run_id, tale_id, entrypoint):
         logging.error(exc, exc_info=True)
         raise
     finally:
-        # Remove the environment.json
-        os.remove(env_json)
+        state.cleanup(False)
 
-        # TODO: _cleanup_volumes
-        for suffix in ['data', 'workspace']:
-            dest = os.path.join(mountpoint, suffix)
-            logging.info("Unmounting %s", dest)
-            subprocess.call("umount %s" % dest, shell=True)
 
-        # Delete the session
-        try:
-            self.girder_client.delete('/dm/session/{}'.format(session['_id']))
-        except Exception as e:
-            logging.error("Unable to remove session. %s", e)
+class RecordedRunCleaner:
+    volume_created = None
+    fs_mounted = None
+    session_created = None
+    env_written = None
 
-        # Delete the Docker volume
-        try:
-            volume = image_builder.dh.cli.volumes.get(vol_name)
+    def __init__(self, run, gc):
+        self.gc = gc
+        self.run = run
+
+    def set_run_status(self, status):
+        self.gc.patch(
+            "/run/{_id}/status".format(**self.run), parameters={'status': status}
+        )
+
+    def cleanup(self, canceled=True):
+        if self.env_written:
+            os.remove(self.env_written)
+            self.env_written = None
+
+        if self.fs_mounted:
+            for suffix in ["data", "workspace"]:
+                dest = os.path.join(self.fs_mounted, suffix)
+                logging.info("Unmounting %s", dest)
+                subprocess.call("umount %s" % dest, shell=True)
+            self.fs_mounted = None
+
+        if self.session_created:
+            # Delete the session
+            try:
+                self.gc.delete('/dm/session/{}'.format(self.session_created))
+            except Exception as e:
+                logging.error("Unable to remove session. %s", e)
+            self.session_created = None
+
+        if self.volume_created:
+            volume = self.volume_created
+            # Delete the Docker volume
             try:
                 logging.info("Removing volume: %s", volume.id)
                 volume.remove()
             except Exception as e:
                 logging.error("Unable to remove volume [%s]: %s", volume.id, e)
-        except docker.errors.NotFound:
-            logging.info("Volume not present [%s].", vol_name)
+            except docker.errors.NotFound:
+                logging.info("Volume not present [%s].", volume.id)
+            self.volume_created = None
+
+        if canceled:
+            self.set_run_status(RunStatus.CANCELED)

--- a/gwvolman/tests/test_build_image.py
+++ b/gwvolman/tests/test_build_image.py
@@ -308,11 +308,16 @@ def test_r2d_calls(depl, dapicli):
 
 
 @mock.patch(
+    "girder_worker.app.Task.canceled",
+    new_callable=mock.PropertyMock,
+    return_value=False
+)
+@mock.patch(
     "gwvolman.utils.Deployment.registry_url",
     new_callable=mock.PropertyMock,
     return_value="https://registry.dev.wholetale.org",
 )
-def test_build_image_task(deployment):
+def test_build_image_task(deployment, task):
     from gwvolman.tasks import build_tale_image
     from gwvolman.constants import TaleStatus
 

--- a/gwvolman/tests/test_recorded_run.py
+++ b/gwvolman/tests/test_recorded_run.py
@@ -122,12 +122,15 @@ def test_recorded_run(
     # This should succeed
     image_builder.return_value.run_r2d.return_value = ({"StatusCode": 0}, "")
     image_builder.return_value.container_config.target_mount = "/work"
-    image_builder.return_value.dh.cli.containers.create.return_value.wait.return_value = \
+    image_builder.return_value.dh.cli.containers.get.return_value.wait.return_value = \
         {"StatusCode": 0}
     image_builder.return_value.dh.cli.containers.create.return_value.id = \
         "container_id"
+    image_builder.return_value.dh.cli.containers.get.return_value.id = \
+        "container_id"
     image_builder.return_value.get_tag.return_value = \
         "registry.test.wholetale.org/123abc/1624994605"
+
     try:
         with mock.patch(
             'gwvolman.utils.Deployment.registry_url', new_callable=mock.PropertyMock
@@ -166,7 +169,7 @@ def test_recorded_run(
     )
 
     # Test execution failure
-    image_builder.return_value.dh.cli.containers.create.return_value.wait.side_effect = \
+    image_builder.return_value.dh.cli.containers.get.return_value.wait.side_effect = \
         ValueError("foo")
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
This adds checks for `task.canceled` in long running tasks: `image_build` and `recorded_run`. In the latter case also tries to clean-up leftovers nicely.

### How to test?
1. Create a Tale, build image (preferably with a custom Dockerfile so you don't hit cache).
2. In girder UI navigate to job view (click on job name in notification). Click 'cancel'. Job should turn to "Cancelling" than "Canceled" after a while.
3. Create a Tale, upload `entrypoint.sh` with steps that take some time (e.g. `echo "1" && sleep 10; echo "2" && sleep 10;...`). Run recorded run. Repeat 2. In dashboard UI run should also be in "Canceled" state in the end.

### TODO:
- [ ] tests...