### PR TITLE
Use build_context when building image for recorded run

### DIFF
--- a/gwvolman/build_utils.py
+++ b/gwvolman/build_utils.py
@@ -212,6 +212,7 @@ class ImageBuilder:
             },
         }
 
+        print(f"Using repo2docker {self.container_config.repo2docker_version}")
         container = self.dh.cli.containers.run(
             image=self.container_config.repo2docker_version,
             command=r2d_cmd,


### PR DESCRIPTION
Fixes https://github.com/whole-tale/whole-tale/issues/126

**Test case:**
* Assumes image has never been built
* Create tale from https://github.com/whole-tale/rrun-test
* Start recorded run without first building image via Run Tale or Build Image
* Confirm that image is built, pushed, and run succeeds.
