### PR TITLE
Add a task for cleaning orphaned rruns

### DIFF
--- a/gwvolman/tests/test_cleanup_tasks.py
+++ b/gwvolman/tests/test_cleanup_tasks.py
@@ -1,0 +1,48 @@
+import docker
+import mock
+from girder_client import GirderClient
+
+
+@mock.patch("docker.from_env")
+def test_check_on_run(dcli):
+    from gwvolman.tasks import check_on_run
+
+    container = mock.MagicMock(spec=docker.models.containers.Container)
+    container.status = "running"
+    dcli.return_value.containers.get.return_value = container
+
+    assert check_on_run({"container_name": "foo"})
+    dcli.return_value.containers.get.assert_called_with("foo")
+
+    dcli.return_value.containers.get.side_effect = docker.errors.NotFound(
+        "404 Client Error for http+docker://localhost/v1.41/containers/foo/json:"
+        'Not Found ("No such container: foo")'
+    )
+    assert not check_on_run({"container_name": "foo"})
+
+
+def test_cleanup_run():
+    from gwvolman.tasks import cleanup_run
+
+    run_with_only_meta = {
+        "_id": "run_id",
+        "meta": {
+            "volume_created": "volume_created",
+            "fs_mounted": "fs_mounted",
+            "session_created": "session_created",
+            "jobId": "jobId",
+        },
+    }
+
+    gc = mock.MagicMock(spec=GirderClient)
+    gc.get.return_value = run_with_only_meta
+
+    cleanup_run.girder_client = gc
+    cleanup_run.job_manager = mock.MagicMock()
+    with mock.patch("gwvolman.tasks.RecordedRunCleaner.cleanup") as cleanup:
+        cleanup_run("run_id")
+
+        gc.get.assert_called_with("/run/run_id")
+        gc.patch.assert_called_with("/run/run_id/status", parameters={"status": 4})
+        gc.put.assert_called_with("/job/jobId", parameters={"status": 4})
+        cleanup.assert_called_with(canceled=False)

--- a/gwvolman/tests/test_recorded_run.py
+++ b/gwvolman/tests/test_recorded_run.py
@@ -53,7 +53,8 @@ RPZ_RUN_CALL = mock.call(
     volumes={
         os.path.join(_mount_point, "data"): {'bind': '/work/data', 'mode': 'rw'},
         os.path.join(_mount_point, "workspace"): {'bind': '/work/workspace', 'mode': 'rw'}
-    }
+    },
+    name="rrun-123456",
 )
 CPR_RUN_CALL = mock.call(
     image='wholetale/wt-cpr:latest',

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -342,7 +342,7 @@ def stop_container(container):
         raise
 
 
-def _recorded_run(cli, mountpoint, container_config, tag, entrypoint, task=None):
+def _recorded_run(cli, mountpoint, container_config, tag, entrypoint, name, task=None):
 
     def logging_worker(log_queue, container):
         for line in container.logs(stream=True):
@@ -367,6 +367,7 @@ def _recorded_run(cli, mountpoint, container_config, tag, entrypoint, task=None)
         image=tag,
         command=run_cmd,
         detach=True,
+        name=name,
         volumes=volumes
     )
 


### PR DESCRIPTION
This adds two tasks:
1. A simple task that return `True` if container named `name` is in a state `running`. Return `False` in every other case.
2. A task that initializes `RecodedRunCleaner` based on data stored in RRun folder (which now happens in recoded run task here: https://github.com/whole-tale/gwvolman/pull/195/files#diff-88a81f7b7546ed0912d4ef71c6547bb35dbb0c312d93c8007e09118dde24ea56R738-R748) and performs cleanup. Additionally it updates the original job with an error status.

companion to https://github.com/whole-tale/wt_versioning/pull/52

Successful clean up should look like this:

```
[2023-03-10 20:45:17,950: INFO/MainProcess] Connected to redis://redis:6379//
[2023-03-10 20:45:17,952: INFO/MainProcess] mingle: searching for neighbors
[2023-03-10 20:45:18,963: INFO/MainProcess] mingle: all alone
[2023-03-10 20:45:18,981: INFO/MainProcess] celery@i4q72m3jebgjdd076x0ifm7b8 ready.
[2023-03-10 20:49:26,596: INFO/MainProcess] Task gwvolman.tasks.check_on_run[0b34fe39-265c-4b2e-9764-cee22dbf6581] received
[2023-03-10 20:49:26,621: INFO/ForkPoolWorker-1] Task gwvolman.tasks.check_on_run[0b34fe39-265c-4b2e-9764-cee22dbf6581] succeeded in 0.011532042997714598s: True
[2023-03-10 20:54:27,803: INFO/MainProcess] Task gwvolman.tasks.check_on_run[cd0ec23a-ecb4-4ef1-9c9f-b776a6b32644] received
[2023-03-10 20:54:27,842: INFO/ForkPoolWorker-1] Task gwvolman.tasks.check_on_run[cd0ec23a-ecb4-4ef1-9c9f-b776a6b32644] succeeded in 0.019145893998938845s: True
[2023-03-10 20:59:28,981: INFO/MainProcess] Task gwvolman.tasks.check_on_run[c7786db6-c177-4890-9e44-2f34ac57fb78] received
[2023-03-10 20:59:29,032: INFO/ForkPoolWorker-1] Task gwvolman.tasks.check_on_run[c7786db6-c177-4890-9e44-2f34ac57fb78] succeeded in 0.03232604300137609s: True
[2023-03-10 21:07:25,089: INFO/MainProcess] Task gwvolman.tasks.check_on_run[21c0d511-c684-42de-87d2-e929ff8ce26a] received
[2023-03-10 21:07:25,108: INFO/MainProcess] Task gwvolman.tasks.cleanup_run[6a457812-fc55-410f-b06e-cd3078644357] received
[2023-03-10 21:07:25,109: INFO/ForkPoolWorker-1] Task gwvolman.tasks.check_on_run[21c0d511-c684-42de-87d2-e929ff8ce26a] succeeded in 0.008413170999119757s: False
[2023-03-10 21:07:25,122: INFO/ForkPoolWorker-1] Unmounting /home/xarth/codes/whole-tale/deploy-dev/volumes/mountpoints/640b96bf9116fbc598f7dce9_kowalikk_CYAXFF/data
[2023-03-10 21:07:25,130: INFO/ForkPoolWorker-1] Unmounting /home/xarth/codes/whole-tale/deploy-dev/volumes/mountpoints/640b96bf9116fbc598f7dce9_kowalikk_CYAXFF/workspace
[2023-03-10 21:07:25,185: INFO/ForkPoolWorker-1] Task gwvolman.tasks.cleanup_run[6a457812-fc55-410f-b06e-cd3078644357] succeeded in 0.06446301499818219s: None
```