### PR TITLE
if tempdir is mounted use the same path for r2d

### DIFF
--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -357,7 +357,7 @@ def build_tale_image(task, tale_id, force=False):
     print("Forcing build.")
 
     # Prepare build context
-    ret, _ = image_builder.run_r2d(tag, image_builder.build_context, task=task)
+    ret, _ = image_builder.run_r2d(tag, task=task)
     if task.canceled:
         task.request.chain = None
         logging.info("Build canceled.")
@@ -574,7 +574,7 @@ def rebuild_image_cache(self):
         )
 
         start = time.time()
-        ret, _ = image_builder.run_r2d(tag, image_builder.build_context)
+        ret, _ = image_builder.run_r2d(tag)
 
         elapsed = int(time.time() - start)
         if ret["StatusCode"] != 0:
@@ -719,7 +719,7 @@ def recorded_run(self, run_id, tale_id, entrypoint):
     try:
         if not image_builder.cached_image(tag):
             print("Building image for recorded run " + tag)
-            ret, _ = image_builder.run_r2d(tag, image_builder.build_context)
+            ret, _ = image_builder.run_r2d(tag)
             if self.canceled:
                 state.cleanup()
                 return

--- a/gwvolman/tests/test_deployment.py
+++ b/gwvolman/tests/test_deployment.py
@@ -1,0 +1,66 @@
+# Write a pytest based test for ..utils.Deployment class
+# mocking all docker.Client calls
+import mock
+import pytest
+
+from gwvolman.utils import Deployment
+
+
+@pytest.fixture
+def deployment():
+    return Deployment()
+
+
+def test_tmpdir_mount(deployment):
+    with mock.patch.object(deployment, "docker_client") as mock_docker_client:
+        mock_docker_client.containers.get.return_value = mock.Mock()
+        mock_docker_client.containers.get.return_value.attrs = {
+            "Mounts": [
+                {
+                    "Destination": "/tmp",
+                    "Source": "/blah/tmp",
+                    "Type": "bind",
+                    "Mode": "rw",
+                    "RW": True,
+                    "Propagation": "rprivate",
+                }
+            ]
+        }
+        assert deployment.tmpdir_mount == "/blah/tmp"
+
+
+def test_traefik_network(deployment):
+    with mock.patch.object(deployment, "docker_client") as mock_docker_client:
+        mock_docker_client.services.get.return_value = mock.Mock()
+        mock_docker_client.services.get.return_value.attrs = {
+            "Spec": {"Labels": {"traefik.docker.network": "traefik"}}
+        }
+        assert deployment.traefik_network == "traefik"
+
+
+def test_dashboard_url(deployment):
+    with mock.patch.object(deployment, "docker_client") as mock_docker_client:
+        mock_docker_client.services.get.return_value = mock.Mock()
+        mock_docker_client.services.get.return_value.attrs = {
+            "Spec": {
+                "Labels": {
+                    "com.docker.stack.namespace": "wt_traefik",
+                    "traefik.http.routers.wt_dashboard.rule": "Host(`dashboard.example.com`)",
+                }
+            }
+        }
+        assert deployment.dashboard_url == "https://dashboard.example.com"
+
+
+def test_girder_url(deployment):
+    with mock.patch.object(deployment, "docker_client") as mock_docker_client:
+        mock_docker_client.services.get.return_value = mock.Mock()
+        mock_docker_client.services.get.return_value.attrs = {
+            "Spec": {
+                "Labels": {
+                    "com.docker.stack.namespace": "wt_traefik",
+                    "traefik.http.routers.wt_girder.rule": "Host(`girder.example.com`)",
+                }
+            }
+        }
+        assert deployment.girder_url == "https://girder.example.com"


### PR DESCRIPTION
Currently we use `TMPDIR` for 2 things:
1. As a place to prepare build context for repo2docker
2. For caching WtDmsGirderFs files.

Due to 2. we need TMPDIR to be fairly big, which we can achieve by mounting a particular resource from host to `celery_worker`'s `/tmp`. However, we now have to make sure that whatever resource is mounted as `/tmp` also gets mounted the same way for r2d container, which is the goal of this PR.

1. Create a new subdirectory in `volumes` called `tmp`, and make sure it has proper acls (`chmod 1777 volumes/tmp`)
2. Modify `run_worker.sh` with:
```diff
--- a/run_worker.sh
+++ b/run_worker.sh
@@ -33,7 +33,7 @@ docker run \
     -e WT_VOLUMES_PATH="$PWD"/volumes \
     -e MATLAB_FILE_INSTALLATION_KEY=${matlab_file_installation_key} \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
-    -v /tmp:/tmp \
+    -v "$PWD"/volumes/tmp:/tmp \
```
3. Checkout this PR and deploy or `make restart_worker`.
4. Create a Tale with external data, build it (optionally `watch -n 1 ls volumes/tmp`). Confirm success
5. In a running Tale, access external data. Confirm `wt*` files are created in `volumes/tmp`