### PR TITLE
Use GirderFS http server for mounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  codecov: codecov/codecov@3
 
 jobs: # A basic unit of work in a run
   build: # runs not using Workflows must have a `build` job as entry point 
@@ -29,6 +31,4 @@ jobs: # A basic unit of work in a run
       - run:
           name: Display coverage reports
           command: coverage report
-      - run:
-          name: Uploading Coverage Results
-          command: codecov
+      - codecov/upload

--- a/gwvolman/__init__.py
+++ b/gwvolman/__init__.py
@@ -1,4 +1,6 @@
 """WholeTale Girder Worker Plugin."""
+import os
+import docker
 from girder_worker import GirderWorkerPluginABC
 from kombu.common import Broadcast, Exchange, Queue
 
@@ -12,13 +14,36 @@ class GWVolumeManagerPlugin(GirderWorkerPluginABC):
         # Here we can also change application settings. E.g.
         # changing the task time limit:
         #
-        self.app.conf.task_queues = (
-            Queue('celery', Exchange('celery', type='direct'),
-                  routing_key='celery'),
-            Broadcast('broadcast_tasks')
-        )
+        queues = []
+        if node_id := os.environ.get("SWARM_NODE_ID"):
+            cli = docker.from_env()
+            node = cli.nodes.get(node_id)
+            if node.attrs["Spec"]["Role"] == "manager":
+                queues.append(
+                    Queue("manager", Exchange("manager", type="direct"), routing_key="manager")
+                )
+
+            if len(cli.nodes.list()) == 1 or node.attrs["Spec"]["Role"] != "manager":
+                queues.append(
+                    Queue("celery", Exchange("celery", type="direct"), routing_key="celery")
+                )
+
+            queues += [
+                Queue(node_id, Exchange(node_id, type="direct"), routing_key=node_id),
+            ]
+        else:
+            queues = [
+                Queue(
+                    "celery",
+                    Exchange("celery", type="direct"),
+                    routing_key="celery",
+                ),
+            ]
+        queues.append(Broadcast("broadcast_tasks"))
+
+        self.app.conf.task_queues = queues
         self.app.conf.task_routes = {
-            'gwvolman.tasks.shutdown_container': {'queue': 'broadcast_tasks'}
+            "gwvolman.tasks.shutdown_container": {"queue": "broadcast_tasks"}
         }
         # self.app.config.update({
         #     'TASK_TIME_LIMIT': 300
@@ -26,4 +51,4 @@ class GWVolumeManagerPlugin(GirderWorkerPluginABC):
 
     def task_imports(self):
         """Return a list of python importable paths."""
-        return ['gwvolman.tasks']
+        return ["gwvolman.tasks"]

--- a/gwvolman/constants.py
+++ b/gwvolman/constants.py
@@ -26,6 +26,10 @@ REPO2DOCKER_VERSION = os.environ.get(
     "REPO2DOCKER_VERSION",
     "wholetale/repo2docker_wholetale:latest"
 )
+GIRDERFS_IMAGE = os.environ.get(
+    "GIRDERFS_IMAGE",
+    "wholetale/girderfs:latest"
+)
 CPR_VERSION = os.environ.get("CPR_VERSION", "wholetale/wt-cpr:latest")
 VOLUMES_ROOT = os.environ.get("WT_VOLUMES_PATH", "/mnt/homes")
 

--- a/gwvolman/fs_container.py
+++ b/gwvolman/fs_container.py
@@ -4,7 +4,7 @@ import time
 import docker
 import requests
 
-from .constants import VOLUMES_ROOT
+from .constants import GIRDERFS_IMAGE, VOLUMES_ROOT
 from .utils import stop_container
 
 
@@ -15,7 +15,7 @@ class FSContainer(object):
         # Create container for handling FUSE mounts
         print("Creating WT Filesystem container...")
         fscontainer = cli.containers.run(
-            image="wholetale/girderfs",
+            image=GIRDERFS_IMAGE,
             name=name,
             detach=True,
             labels={"traefik.enable": "false"},

--- a/gwvolman/fs_container.py
+++ b/gwvolman/fs_container.py
@@ -1,0 +1,75 @@
+# Description: Context manager for changing the current working directory
+
+import time
+import docker
+import requests
+
+from .constants import VOLUMES_ROOT
+from .utils import stop_container
+
+
+class FSContainer(object):
+    @staticmethod
+    def start_container(name):
+        cli = docker.from_env()
+        # Create container for handling FUSE mounts
+        print("Creating WT Filesystem container...")
+        fscontainer = cli.containers.run(
+            image="wholetale/girderfs",
+            name=name,
+            detach=True,
+            labels={"traefik.enable": "false"},
+            mounts=[
+                docker.types.Mount(
+                    target=VOLUMES_ROOT,
+                    source=VOLUMES_ROOT,
+                    type="bind",
+                    propagation="rshared",
+                ),
+            ],
+            environment={
+                "WT_VOLUMES_PATH": VOLUMES_ROOT,
+            },
+            devices=["/dev/fuse"],
+            cap_add=["SYS_ADMIN"],
+            security_opt=["apparmor:unconfined"],
+            network="wt_celery",
+            remove=True,
+        )
+        # wait for the container to be up and running
+        # fail after 30s
+        t = 0
+        while True:
+            time.sleep(1)
+            try:
+                fscontainer.reload()
+            except docker.errors.NotFound:
+                raise Exception("Failed to create WT Filesystem container")
+            if fscontainer.status == "running":
+                break
+            if t > 30 or fscontainer.status == "exited":
+                raise Exception("Failed to create WT Filesystem container")
+            t += 1
+        return fscontainer
+
+    @staticmethod
+    def mount(container, payload):
+        # send payload to fscontainer using requests
+        print("Sending payload to WT Filesystem container...")
+        response = requests.post(
+            f"http://{container.name}:8888/",
+            json=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+
+    @staticmethod
+    def stop_container(name):
+        print("Sending shutdown request to WT Filesystem container...")
+        cli = docker.from_env()
+        try:
+            container = cli.containers.get(name)
+        except docker.errors.NotFound:
+            return
+        requests.delete(f"http://{container.name}:8888/")
+        stop_container(container)

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -270,12 +270,15 @@ def shutdown_container(self, instanceId):
 @app.task(bind=True)
 def remove_volume(self, instanceId):
     """Unmount WT-fs and remove mountpoint."""
+    logging.info("Stopping FS container for instance %s", instanceId)
     user, instance = _get_user_and_instance(self.girder_client, instanceId)
 
     if 'containerInfo' not in instance:
+        logging.warning("No containerInfo for instance %s", instanceId)
         return
     containerInfo = instance["containerInfo"]  # VALIDATE
     FSContainer.stop_container(containerInfo["fscontainerId"])
+    logging.info("FS container %s stopped", containerInfo["fscontainerId"])
 
 
 @girder_job(title='Build Tale Image')

--- a/gwvolman/tasks.py
+++ b/gwvolman/tasks.py
@@ -4,15 +4,10 @@ import os
 import json
 import time
 import docker
-import shutil
-import subprocess
+from urllib.parse import urlparse
 import girder_client
 
 import logging
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
 from girder_worker.utils import girder_job
 from girder_worker.app import app
 # from girder_worker.plugins.docker.executor import _pull_image
@@ -21,12 +16,12 @@ from .utils import \
     new_user, _safe_mkdir, _get_api_key, \
     _get_container_config, _launch_container, _get_user_and_instance, \
     _recorded_run, DEPLOYMENT, stop_container
+from .fs_container import FSContainer
 
 from .lib.zenodo import ZenodoPublishProvider
 
-from .constants import GIRDER_API_URL, InstanceStatus, ENABLE_WORKSPACES, \
-    MOUNTPOINTS, VOLUMES_ROOT, TaleStatus, \
-    RunStatus
+from .constants import GIRDER_API_URL, InstanceStatus, \
+    TaleStatus, RunStatus, VOLUMES_ROOT
 
 CREATE_VOLUME_STEP_TOTAL = 2
 LAUNCH_CONTAINER_STEP_TOTAL = 2
@@ -36,12 +31,6 @@ IMPORT_TALE_STEP_TOTAL = 2
 RECORDED_RUN_STEP_TOTAL = 4
 
 
-def _create_mount_point(vol_name):
-    mountpoint = os.path.join(VOLUMES_ROOT, "mountpoints", vol_name)
-    _safe_mkdir(mountpoint)
-    return mountpoint
-
-
 @girder_job(title='Create Tale Data Volume')
 @app.task(bind=True)
 def create_volume(self, instance_id):
@@ -49,41 +38,57 @@ def create_volume(self, instance_id):
     user, instance = _get_user_and_instance(self.girder_client, instance_id)
     tale = self.girder_client.get('/tale/{taleId}'.format(**instance))
 
-    vol_name = "%s_%s_%s" % (tale['_id'], user['login'], new_user(6))
-    cli = docker.from_env(version='1.28')
-
     self.job_manager.updateProgress(
         message='Creating volume', total=CREATE_VOLUME_STEP_TOTAL,
         current=1, forceFlush=True)
 
-    mountpoint = _create_mount_point(vol_name)
-
-    _make_fuse_dirs(mountpoint, MOUNTPOINTS)
-
-    api_key = _get_api_key(self.girder_client)
-
-    session = _get_session(self.girder_client, tale=tale)
-
-    if session['_id'] is not None:
-        _mount_girderfs(mountpoint, 'data', 'wt_dms', session['_id'], api_key, hostns=False)
-
-    _mount_bind(mountpoint, 'home', user)
-
-    if ENABLE_WORKSPACES:
-        _mount_bind(mountpoint, 'workspace', tale)
-        _mount_girderfs(mountpoint, 'versions', 'wt_versions', tale['_id'], api_key, hostns=False)
-        _mount_girderfs(mountpoint, 'runs', 'wt_runs', tale['_id'], api_key, hostns=False)
-
+    vol_name = "%s_%s_%s" % (tale['_id'], user['login'], new_user(6))
+    fs_sidecar = FSContainer.start_container(vol_name)
+    payload = {
+        "mounts": [
+            {
+                "type": "data",
+                "protocol": "girderfs",
+                "location": "data",
+            },
+            {
+                "type": "home",
+                "protocol": "bind",
+                "location": "home",
+            },
+            {
+                "type": "workspace",
+                "protocol": "bind",
+                "location": "workspace",
+            },
+            {
+                "type": "versions",
+                "protocol": "girderfs",
+                "location": "versions",
+            },
+            {
+                "type": "runs",
+                "protocol": "girderfs",
+                "location": "runs",
+            },
+        ],
+        "taleId": tale["_id"],
+        "userId": user["_id"],
+        "girderApiUrl": GIRDER_API_URL,
+        "girderApiKey": _get_api_key(self.girder_client),
+        "root": vol_name,
+    }
+    FSContainer.mount(fs_sidecar, payload)
     self.job_manager.updateProgress(
         message='Volume created', total=CREATE_VOLUME_STEP_TOTAL,
         current=CREATE_VOLUME_STEP_TOTAL, forceFlush=True)
     print("WT Filesystem created successfully.")
 
+    cli = docker.from_env()
     return dict(
         nodeId=cli.info()['Swarm']['NodeID'],
-        mountPoint=mountpoint,
+        fscontainerId=fs_sidecar.id,
         volumeName=vol_name,
-        sessionId=session["_id"],
         instanceId=instance_id,
         taleId=tale["_id"],
     )
@@ -269,35 +274,8 @@ def remove_volume(self, instanceId):
 
     if 'containerInfo' not in instance:
         return
-    containerInfo = instance['containerInfo']  # VALIDATE
-
-    cli = docker.from_env(version='1.28')
-    # TODO: _remove_volumes()
-    for suffix in MOUNTPOINTS:
-        dest = os.path.join(containerInfo['mountPoint'], suffix)
-        logging.info("Unmounting %s", dest)
-        subprocess.call("sudo umount %s" % dest, shell=True)
-
-    logging.info("Unmounting licenses")
-    subprocess.call("sudo umount /licenses", shell=True)
-
-    try:
-        self.girder_client.delete('/dm/session/{sessionId}'.format(**instance))
-    except Exception as e:
-        logging.error("Unable to remove session. %s", e)
-        pass
-
-    try:
-        volume = cli.volumes.get(containerInfo['volumeName'])
-    except docker.errors.NotFound:
-        logging.info("Volume not present [%s].", containerInfo['volumeName'])
-        return
-    try:
-        logging.info("Removing volume: %s", volume.id)
-        volume.remove()
-    except Exception as e:
-        logging.error("Unable to remove volume [%s]: %s", volume.id, e)
-        pass
+    containerInfo = instance["containerInfo"]  # VALIDATE
+    FSContainer.stop_container(containerInfo["fscontainerId"])
 
 
 @girder_job(title='Build Tale Image')
@@ -583,60 +561,10 @@ def rebuild_image_cache(self):
             logging.info("Build time: %i seconds", elapsed)
 
 
-def _mount_bind(mountpoint, res_type, obj):
-    if res_type == "home":
-        source_path = f"{VOLUMES_ROOT}/homes/{obj['login'][0]}/{obj['login']}"
-    elif res_type == "workspace":
-        source_path = f"{VOLUMES_ROOT}/workspaces/{obj['_id'][0]}/{obj['_id']}"
-    elif res_type == "run":
-        source_path = (
-            f"{VOLUMES_ROOT}/runs/{obj['taleId'][0:2]}/{obj['taleId']}/"
-            f"{obj['runId']}/workspace"
-        )
-        res_type = "workspace"
-    else:
-        raise ValueError(f"Unknown bind type {res_type}")
-    cmd = f"sudo mount --bind {source_path} {mountpoint}/{res_type}"
-    logging.info("Calling: %s", cmd)
-    subprocess.check_call(cmd, shell=True)
-    print(f"Mounted {source_path} to {mountpoint}/{res_type}")
-
-
-def _mount_girderfs(mountpoint, directory, fs_type, obj_id, api_key, hostns=False):
-
-    hostns_flag = '--hostns' if hostns else ''
-
-    """Mount a girderfs directory given a type and id"""
-    cmd = (
-        f"girderfs {hostns_flag} -c {fs_type} --api-url {GIRDER_API_URL} --api-key {api_key}"
-        f" {os.path.join(mountpoint, directory)} {obj_id}"
-    )
-    logging.info("Calling: %s", cmd)
-    subprocess.check_call(cmd, shell=True)
-    print(f"Mounted {fs_type} {directory}")
-
-
 def _make_fuse_dirs(mountpoint, directories):
     """Create fuse directories"""
     for suffix in directories:
         _safe_mkdir(os.path.join(mountpoint, suffix))
-
-
-def _get_session(gc, tale=None, version_id=None):
-    """Returns the session for a tale or version"""
-    session = {'_id': None}
-
-    if tale is not None and tale.get('dataSet') is not None:
-        session = gc.post(
-            '/dm/session', parameters={'taleId': tale['_id']})
-    elif version_id is not None:
-        # Get the dataset for the version
-        dataset = gc.get('/version/{}/dataSet'.format(version_id))
-        if dataset is not None:
-            session = gc.post(
-                '/dm/session', parameters={'dataSet': json.dumps(dataset)})
-
-    return session
 
 
 def _write_env_json(workspace_dir, image):
@@ -682,21 +610,29 @@ def recorded_run(self, run_id, tale_id, entrypoint):
 
     # Create Docker volume
     vol_name = "%s_%s_%s" % (run_id, user['login'], new_user(6))
-    mountpoint = _create_mount_point(vol_name)
-    state.volume_created = mountpoint
-
-    # Create fuse directories
-    _make_fuse_dirs(mountpoint, ['data', 'workspace'])
-
-    # Mount data and workspace for the run
-    api_key = _get_api_key(self.girder_client)
-    session = _get_session(self.girder_client, version_id=run['runVersionId'])
-    state.session_created = session["_id"]
-
-    if session['_id'] is not None:
-        _mount_girderfs(mountpoint, 'data', 'wt_dms', session['_id'], api_key, hostns=False)
-    _mount_bind(mountpoint, "run", {"runId": run["_id"], "taleId": tale["_id"]})
-    state.fs_mounted = mountpoint
+    fs_sidecar = FSContainer.start_container(vol_name)
+    payload = {
+        "mounts": [
+            {
+                "type": "data",
+                "protocol": "girderfs",
+                "location": "data",
+            },
+            {
+                "type": "run",
+                "protocol": "bind",
+                "location": "workspace",
+            },
+        ],
+        "girderApiUrl": GIRDER_API_URL,
+        "girderApiKey": _get_api_key(self.girder_client),
+        "root": vol_name,
+        "taleId": tale["_id"],
+        "runId": run["_id"],
+        "userId": user["_id"],
+    }
+    FSContainer.mount(fs_sidecar, payload)
+    state.volume_created = vol_name
 
     # Build the image for the run
     self.job_manager.updateProgress(
@@ -740,11 +676,11 @@ def recorded_run(self, run_id, tale_id, entrypoint):
             {
                 "container_name": container_name,
                 "volume_created": state.volume_created,
-                "fs_mounted": state.fs_mounted,
-                "session_created": state.session_created,
                 "node_id": image_builder.dh.cli.info()["Swarm"]["NodeID"],
             }
         )
+
+        mountpoint = os.path.join(VOLUMES_ROOT, "mountpoints", state.volume_created)
 
         _recorded_run(
             image_builder.dh.cli,
@@ -786,8 +722,6 @@ def cleanup_run(self, run_id):
     run = self.girder_client.get(f"/run/{run_id}")
     state = RecordedRunCleaner(run, self.girder_client)
     state.volume_created = run["meta"].get("volume_created")
-    state.fs_mounted = run["meta"].get("fs_mounted")
-    state.session_created = run["meta"].get("session_created")
     state.container_name = run["meta"].get("container_name")
     state.cleanup(canceled=False)
     state.set_run_status(RunStatus.FAILED)
@@ -797,8 +731,6 @@ def cleanup_run(self, run_id):
 
 class RecordedRunCleaner:
     volume_created = None
-    fs_mounted = None
-    session_created = None
     container_name = None
 
     def __init__(self, run, gc):
@@ -816,23 +748,8 @@ class RecordedRunCleaner:
             container = self.docker_cli.containers.get(self.container_name)
             stop_container(container)
 
-        if self.fs_mounted:
-            for suffix in ["data", "workspace"]:
-                dest = os.path.join(self.fs_mounted, suffix)
-                logging.info("Unmounting %s", dest)
-                subprocess.call("sudo umount %s" % dest, shell=True)
-            self.fs_mounted = None
-
-        if self.session_created:
-            # Delete the session
-            try:
-                self.gc.delete('/dm/session/{}'.format(self.session_created))
-            except Exception as e:
-                logging.error("Unable to remove session. %s", e)
-            self.session_created = None
-
         if self.volume_created:
-            shutil.rmtree(self.volume_created, ignore_errors=True)
+            FSContainer.stop_container(self.volume_created)
             self.volume_created = None
 
         if canceled:

--- a/gwvolman/tests/__init__.py
+++ b/gwvolman/tests/__init__.py
@@ -64,10 +64,10 @@ TALE = {
             "@type": "schema:Person",
             "schema:email": "thelen@nceas.ucsb.edu",
             "schema:familyName": "T",
-            "schema:givenName": "Thomas"
+            "schema:givenName": "Thomas",
         },
         "schema:dateModified": "2021-02-20T18:19:31.012000+00:00",
-        "schema:name": "empty"
+        "schema:name": "empty",
     },
 }
 
@@ -93,7 +93,7 @@ TALE_NO_DESC = {
             "doi: 10.5065/D6862DM8."
         )
     ],
-    "description": '',
+    "description": "",
     "dct:hasVersion": {
         "@id": "https://data.wholetale.org/api/v1/folder/603152b34ac3a96578dda45d",
         "@type": "wt:TaleVersion",
@@ -102,10 +102,10 @@ TALE_NO_DESC = {
             "@type": "schema:Person",
             "schema:email": "thelen@nceas.ucsb.edu",
             "schema:familyName": "T",
-            "schema:givenName": "Thomas"
+            "schema:givenName": "Thomas",
         },
         "schema:dateModified": "2021-02-20T18:19:31.012000+00:00",
-        "schema:name": "empty"
+        "schema:name": "empty",
     },
 }
 
@@ -163,10 +163,10 @@ PUBLISHED_TALE = {
             "@type": "schema:Person",
             "schema:email": "thelen@nceas.ucsb.edu",
             "schema:familyName": "T",
-            "schema:givenName": "Thomas"
+            "schema:givenName": "Thomas",
         },
         "schema:dateModified": "2021-02-20T18:19:31.012000+00:00",
-        "schema:name": "empty"
+        "schema:name": "empty",
     },
     "folderId": "5cfd57fca18691e5d1feeda8",
     "format": 7,
@@ -184,8 +184,9 @@ PUBLISHED_TALE = {
             "pid": "doi:10.5072/zenodo.670350",
             "repository": "sandbox.zenodo.org",
             "repository_id": "670350",
-            "uri": "https://sandbox.zenodo.org/record/670350"
-        }],
+            "uri": "https://sandbox.zenodo.org/record/670350",
+        }
+    ],
     "title": "Example Tale: Mapping Estimated Water Usage",
     "updated": "2019-10-08T17:44:29.523000+00:00",
 }
@@ -238,10 +239,10 @@ PARENT_TALE = {
             "@type": "schema:Person",
             "schema:email": "thelen@nceas.ucsb.edu",
             "schema:familyName": "T",
-            "schema:givenName": "Thomas"
+            "schema:givenName": "Thomas",
         },
         "schema:dateModified": "2021-02-20T18:19:31.012000+00:00",
-        "schema:name": "empty"
+        "schema:name": "empty",
     },
     "folderId": "5cfd57fca18691e5d1feeda8",
     "format": 7,
@@ -306,10 +307,10 @@ COPIED_TALE = {
             "@type": "schema:Person",
             "schema:email": "thelen@nceas.ucsb.edu",
             "schema:familyName": "T",
-            "schema:givenName": "Thomas"
+            "schema:givenName": "Thomas",
         },
         "schema:dateModified": "2021-02-20T18:19:31.012000+00:00",
-        "schema:name": "empty"
+        "schema:name": "empty",
     },
     "folderId": "5cfd57fca18691e5d1feeda8",
     "format": 7,

--- a/gwvolman/tests/conftest.py
+++ b/gwvolman/tests/conftest.py
@@ -1,8 +1,11 @@
 # content of conftest.py
 def pytest_configure(config):
     import sys
+
     sys._called_from_test = True
+
 
 def pytest_unconfigure(config):
     import sys  # This was missing from the manual
+
     del sys._called_from_test

--- a/gwvolman/tests/lib/test_publish_provider.py
+++ b/gwvolman/tests/lib/test_publish_provider.py
@@ -3,7 +3,14 @@ import pytest
 from girder_client import GirderClient
 
 from gwvolman.lib.publish_provider import PublishProvider, NullManager
-from gwvolman.tests import TALE, PUBLISHED_TALE, ZENODO_TOKEN, MANIFEST, TALE_NO_DESC, mock_gc_get
+from gwvolman.tests import (
+    TALE,
+    PUBLISHED_TALE,
+    ZENODO_TOKEN,
+    MANIFEST,
+    TALE_NO_DESC,
+    mock_gc_get,
+)
 
 
 def test_ctor():
@@ -11,15 +18,15 @@ def test_ctor():
     mock_req = mock.MagicMock()
     mock_gc.get = mock_gc_get
     mock_gc.sendRestRequest.return_value = mock_req
-    version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
-    provider = PublishProvider(mock_gc, TALE['_id'], ZENODO_TOKEN, version_id)
+    version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
+    provider = PublishProvider(mock_gc, TALE["_id"], ZENODO_TOKEN, version_id)
     assert provider.tale == TALE
     assert isinstance(provider.job_manager, NullManager)
     assert provider.manifest == MANIFEST
 
     # Test without a Tale description
     with pytest.raises(AssertionError):
-        PublishProvider(mock_gc, TALE_NO_DESC['_id'], ZENODO_TOKEN, version_id)
+        PublishProvider(mock_gc, TALE_NO_DESC["_id"], ZENODO_TOKEN, version_id)
 
 
 def test_published():
@@ -27,11 +34,11 @@ def test_published():
     mock_req = mock.MagicMock()
     mock_gc.get = mock_gc_get
     mock_gc.sendRestRequest.return_value = mock_req
-    version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
-    provider = PublishProvider(mock_gc, TALE['_id'], ZENODO_TOKEN, version_id)
+    version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
+    provider = PublishProvider(mock_gc, TALE["_id"], ZENODO_TOKEN, version_id)
     assert provider.published is False
 
-    provider = PublishProvider(mock_gc, PUBLISHED_TALE['_id'], ZENODO_TOKEN, version_id)
+    provider = PublishProvider(mock_gc, PUBLISHED_TALE["_id"], ZENODO_TOKEN, version_id)
     assert provider.published is True
 
 
@@ -40,8 +47,8 @@ def test_publication_info():
     mock_req = mock.MagicMock()
     mock_gc.get = mock_gc_get
     mock_gc.sendRestRequest.return_value = mock_req
-    version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
-    provider = PublishProvider(mock_gc, PUBLISHED_TALE['_id'], ZENODO_TOKEN, version_id)
+    version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
+    provider = PublishProvider(mock_gc, PUBLISHED_TALE["_id"], ZENODO_TOKEN, version_id)
     assert len(provider.publication_info) > 0
 
 
@@ -50,9 +57,9 @@ def test_access_token():
     mock_req = mock.MagicMock()
     mock_gc.get = mock_gc_get
     mock_gc.sendRestRequest.return_value = mock_req
-    version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
-    provider = PublishProvider(mock_gc, PUBLISHED_TALE['_id'], ZENODO_TOKEN, version_id)
-    assert provider.access_token == ZENODO_TOKEN['access_token']
+    version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
+    provider = PublishProvider(mock_gc, PUBLISHED_TALE["_id"], ZENODO_TOKEN, version_id)
+    assert provider.access_token == ZENODO_TOKEN["access_token"]
 
 
 def test_resource_server_token():
@@ -60,9 +67,9 @@ def test_resource_server_token():
     mock_req = mock.MagicMock()
     mock_gc.get = mock_gc_get
     mock_gc.sendRestRequest.return_value = mock_req
-    version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
-    provider = PublishProvider(mock_gc, PUBLISHED_TALE['_id'], ZENODO_TOKEN, version_id)
-    assert provider.resource_server == ZENODO_TOKEN['resource_server']
+    version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
+    provider = PublishProvider(mock_gc, PUBLISHED_TALE["_id"], ZENODO_TOKEN, version_id)
+    assert provider.resource_server == ZENODO_TOKEN["resource_server"]
 
 
 def test_publish():
@@ -71,6 +78,8 @@ def test_publish():
         mock_req = mock.MagicMock()
         mock_gc.get = mock_gc_get
         mock_gc.sendRestRequest.return_value = mock_req
-        version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
-        provider = PublishProvider(mock_gc, PUBLISHED_TALE['_id'], ZENODO_TOKEN, version_id)
+        version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
+        provider = PublishProvider(
+            mock_gc, PUBLISHED_TALE["_id"], ZENODO_TOKEN, version_id
+        )
         provider.publish()

--- a/gwvolman/tests/lib/test_zenodo_publish.py
+++ b/gwvolman/tests/lib/test_zenodo_publish.py
@@ -130,7 +130,7 @@ def mock_create_deposit_fail(url, request):
 )
 def mock_deposit_files_ok(url, request):
     assert request.headers["Authorization"] == "Bearer zenodo_api_key"
-    version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
+    version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
     assert request.original.data == {"name": f"{version_id}.zip"}
     return httmock.response(
         status_code=201,
@@ -156,7 +156,7 @@ def mock_deposit_files_ok(url, request):
 )
 def mock_deposit_files_fail(url, request):
     assert request.headers["Authorization"] == "Bearer zenodo_api_key"
-    version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
+    version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
     assert request.original.data == {"name": f"{version_id}.zip"}
     return httmock.response(
         status_code=404,
@@ -361,7 +361,7 @@ def mock_tale_update_draft(path, json=None):
 
 def stream_response(chunk_size=65536):
     test_path = os.path.dirname(__file__)
-    version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
+    version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
     with open("{}/../data/{}.zip".format(test_path, version_id), "rb") as fp:
         while True:
             data = fp.read(chunk_size)
@@ -389,7 +389,7 @@ def test_zenodo_publish():
         mock_delete_deposition,
         mock_other_request,
     ):
-        version_id = TALE['dct:hasVersion']['@id'].rsplit('/', 1)[-1]
+        version_id = TALE["dct:hasVersion"]["@id"].rsplit("/", 1)[-1]
         with pytest.raises(ValueError) as error:
             publish("123", ZENODO_TOKEN, version_id, repository="sandbox.zenodo.org")
 
@@ -434,7 +434,9 @@ def test_zenodo_publish():
         mock_publish_deposit_ok,
         mock_other_request,
     ):
-        publish("123", ZENODO_TOKEN, version_id, repository="sandbox.zenodo.org", draft=True)
+        publish(
+            "123", ZENODO_TOKEN, version_id, repository="sandbox.zenodo.org", draft=True
+        )
 
     mock_gc.put = lambda: (_ for _ in ()).throw(Exception("Girder Died"))
     with httmock.HTTMock(
@@ -460,4 +462,9 @@ def test_zenodo_publish():
         with mock.patch(
             "gwvolman.tasks.ZenodoPublishProvider.publish_version", lambda x, y: None
         ):
-            publish("already_published", ZENODO_TOKEN, version_id, repository="sandbox.zenodo.org")
+            publish(
+                "already_published",
+                ZENODO_TOKEN,
+                version_id,
+                repository="sandbox.zenodo.org",
+            )

--- a/gwvolman/tests/test_build_image.py
+++ b/gwvolman/tests/test_build_image.py
@@ -189,9 +189,7 @@ def test_image_builder(dtmp, depl, dapicli):
         )
 
 
-@mock.patch.dict(
-    os.environ, {"MATLAB_FILE_INSTALLATION_KEY": "fake-key"}
-)
+@mock.patch.dict(os.environ, {"MATLAB_FILE_INSTALLATION_KEY": "fake-key"})
 @mock.patch("docker.APIClient")
 @mock.patch(
     "gwvolman.utils.Deployment.registry_url",
@@ -227,9 +225,7 @@ def test_r2d_calls(dtmp, depl, dapicli):
         image_builder = ImageBuilder(gc, tale=tale)
         with pytest.raises(ValueError) as ex:
             image_builder.pull_r2d()
-        assert ex.match(
-            f"Requested r2d image '{REPO2DOCKER_VERSION}' not found."
-        )
+        assert ex.match(f"Requested r2d image '{REPO2DOCKER_VERSION}' not found.")
 
     with mock.patch("docker.from_env") as dcli:
         mock_container_run = mock.MagicMock(wraps=docker_run_r2d_container)
@@ -307,8 +303,14 @@ def test_r2d_calls(dtmp, depl, dapicli):
                 detach=True,
                 remove=True,
                 volumes={
-                    "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},
-                    f"/tmp/{subdir}": {"bind": image_builder.build_context, "mode": "ro"},
+                    "/var/run/docker.sock": {
+                        "bind": "/var/run/docker.sock",
+                        "mode": "rw",
+                    },
+                    f"/tmp/{subdir}": {
+                        "bind": image_builder.build_context,
+                        "mode": "ro",
+                    },
                 },
             )
             ret, _ = image_builder.run_r2d(
@@ -320,7 +322,7 @@ def test_r2d_calls(dtmp, depl, dapicli):
 @mock.patch(
     "girder_worker.app.Task.canceled",
     new_callable=mock.PropertyMock,
-    return_value=False
+    return_value=False,
 )
 @mock.patch(
     "gwvolman.utils.Deployment.registry_url",

--- a/gwvolman/tests/test_deployment.py
+++ b/gwvolman/tests/test_deployment.py
@@ -13,18 +13,24 @@ def deployment():
 
 def test_tmpdir_mount(deployment):
     with mock.patch.object(deployment, "docker_client") as mock_docker_client:
-        mock_docker_client.containers.get.return_value = mock.Mock()
-        mock_docker_client.containers.get.return_value.attrs = {
-            "Mounts": [
-                {
-                    "Destination": "/tmp",
-                    "Source": "/blah/tmp",
-                    "Type": "bind",
-                    "Mode": "rw",
-                    "RW": True,
-                    "Propagation": "rprivate",
+        mock_docker_client.services.get.return_value = mock.Mock()
+        mock_docker_client.services.get.return_value.attrs = {
+            "Spec": {
+                "TaskTemplate": {
+                    "ContainerSpec": {
+                        "Mounts": [
+                            {
+                                "Target": "/tmp",
+                                "Source": "/blah/tmp",
+                                "Type": "bind",
+                                "Mode": "rw",
+                                "RW": True,
+                                "Propagation": "rprivate",
+                            }
+                        ]
+                    }
                 }
-            ]
+            }
         }
         assert deployment.tmpdir_mount == "/blah/tmp"
 

--- a/gwvolman/tests/test_volumes.py
+++ b/gwvolman/tests/test_volumes.py
@@ -2,17 +2,16 @@ from girder_client import GirderClient
 import mock
 import os
 
-os.environ['GIRDER_API_URL'] = 'https://girder.dev.wholetale.org/api/v1'
+os.environ["GIRDER_API_URL"] = "https://girder.dev.wholetale.org/api/v1"
 
-from gwvolman.tasks import create_volume, _mount_girderfs, \
-    _make_fuse_dirs, _get_session # noqa
+from gwvolman.tasks import create_volume
 
 
 def mock_gc_post(path, parameters=None):
     if path in ("/dm/session"):
-        if 'taleId' in parameters:
+        if "taleId" in parameters:
             return {"_id": "session1"}
-        elif 'dataSet' in parameters:
+        elif "dataSet" in parameters:
             return {"_id": "session2"}
 
 
@@ -29,98 +28,60 @@ def mock_gc_get(path, parameters=None):
 
 @mock.patch("gwvolman.tasks.new_user", return_value="123456")
 @mock.patch("os.mkdir", return_value=None)
-@mock.patch("docker.client.DockerClient.info", return_value={'Swarm': {'NodeID': 'node1'}})
+@mock.patch(
+    "docker.client.DockerClient.info", return_value={"Swarm": {"NodeID": "node1"}}
+)
 @mock.patch("gwvolman.tasks._get_api_key", return_value="apikey1")
-@mock.patch("gwvolman.tasks._get_session", return_value={"_id": "session1"})
-@mock.patch("gwvolman.tasks._make_fuse_dirs", return_value=True)
-@mock.patch("gwvolman.tasks._mount_girderfs", return_value=True)
-@mock.patch("gwvolman.tasks._mount_bind", return_value=True)
-def test_create_volume(mbind, mgfs, mfd, gs, gak, info, osmk, nu):
-
+def test_create_volume(gak, info, osmk, nu):
     mock_gc = mock.MagicMock(spec=GirderClient)
     mock_gc.get = mock_gc_get
-    mock_gc.loadOrCreateFolder = mock.Mock(return_value={'_id': 'folder1'})
+    mock_gc.loadOrCreateFolder = mock.Mock(return_value={"_id": "folder1"})
 
     create_volume.girder_client = mock_gc
     create_volume.job_manager = mock.MagicMock()
 
-    mount_point = "/mnt/homes/mountpoints/tale1_user1_123456"
+    with mock.patch("docker.from_env") as mock_docker, mock.patch(
+        "requests.post"
+    ) as mock_post:
+        mock_docker.return_value = mock.MagicMock()
+        # mock docker info
+        mock_docker.return_value.info.return_value = {"Swarm": {"NodeID": "node1"}}
+        # define magick mock for the container
+        mock_status = mock.PropertyMock(side_effect=["starting", "running", "running"])
+        fscontainer = mock.MagicMock(
+            id="container1",
+            name="tale1_user1_123456",
+        )
+        type(fscontainer).status = mock_status
+        mock_docker.return_value.containers.run.return_value = fscontainer
 
-    try:
-        ret = create_volume('instance1')
+        ret = create_volume("instance1")
 
-        expected = {
-            'nodeId': 'node1',
-            'mountPoint': mount_point,
-            'sessionId': 'session1',
-            'instanceId': 'instance1',
-            'taleId': "tale1",
-            'volumeName': 'tale1_user1_123456',
+        data = {
+            "mounts": [
+                {"type": "data", "protocol": "girderfs", "location": "data"},
+                {"type": "home", "protocol": "bind", "location": "home"},
+                {"type": "workspace", "protocol": "bind", "location": "workspace"},
+                {"type": "versions", "protocol": "girderfs", "location": "versions"},
+                {"type": "runs", "protocol": "girderfs", "location": "runs"},
+            ],
+            "taleId": "tale1",
+            "userId": "ghi567",
+            "girderApiUrl": "https://girder.dev.wholetale.org/api/v1",
+            "girderApiKey": "apikey1",
+            "root": "tale1_user1_123456",
         }
+        headers = {"Content-Type": "application/json"}
+        mock_post.assert_called_with(
+            f"http://{fscontainer.name}:8888/", json=data, headers=headers
+        )
 
-        assert ret == expected
-    except ValueError:
-        assert False
-
-    osmk.assert_has_calls([
-        mock.call("/mnt/homes/mountpoints/tale1_user1_123456")
-    ])
-
-    mbind.assert_has_calls([
-        mock.call(mount_point, 'home', {'_id': 'ghi567', 'login': 'user1'}),
-        mock.call(mount_point, 'workspace', {'_id': 'tale1'}),
-    ])
-    mgfs.assert_has_calls([
-        mock.call(mount_point, 'data', 'wt_dms', 'session1',
-                  'apikey1', hostns=False),
-        mock.call(mount_point, 'versions', 'wt_versions', 'tale1',
-                  'apikey1', hostns=False),
-        mock.call(mount_point, 'runs', 'wt_runs', 'tale1', 'apikey1',
-                  hostns=False)
-        ], any_order=False)
-
-
-@mock.patch("subprocess.check_call", return_value=True)
-def test_mount_girderfs(spcc):
-
-    _mount_girderfs('/path/to/mountpoint', 'home', 'wt_home', 'folder1', 'apikey1')
-
-    _mount_girderfs('/path/to/mountpoint', 'data', 'wt_dms', 'session1', 'apikey1', True)
-
-    spcc.assert_has_calls([
-        mock.call('girderfs  -c wt_home --api-url https://girder.dev.wholetale.org/api/v1'
-                  ' --api-key apikey1 /path/to/mountpoint/home folder1', shell=True),
-        mock.call('girderfs --hostns -c wt_dms --api-url https://girder.dev.wholetale.org/api/v1'
-                  ' --api-key apikey1 /path/to/mountpoint/data session1', shell=True)
-        ], any_order=False)
-
-
-@mock.patch("os.mkdir", return_value=True)
-def test_make_fuse_dirs(mkdir):
-
-    with mock.patch('os.path.isdir', return_value=True):
-        _make_fuse_dirs('/path/to/mountpoint', ['dir1'])
-
-    mkdir.assert_has_calls([mock.call('/path/to/mountpoint/dir1')], any_order=False)
-
-
-def test_get_session():
-
-    mock_tale = {
-        '_id': 'tale1',
-        'dataSet': {
-            '_modelType': 'item',
-            'itemId': '60d4897ce13fb71b1c179fe4',
-            'mountPath': 'usco2000.xls'
-        }
+    expected = {
+        "nodeId": "node1",
+        "fscontainerId": "container1",
+        "instanceId": "instance1",
+        "taleId": "tale1",
+        "volumeName": "tale1_user1_123456",
     }
 
-    mock_gc = mock.MagicMock(spec=GirderClient)
-    mock_gc.post = mock_gc_post
-    mock_gc.get = mock_gc_get
-
-    session1 = _get_session(mock_gc, tale=mock_tale)
-    assert session1['_id'] == 'session1'
-
-    session2 = _get_session(mock_gc, tale=None, version_id='version1')
-    assert session2['_id'] == 'session2'
+    assert ret == expected

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -79,10 +79,11 @@ class Deployment(object):
     def tmpdir_mount(self):
         """str: Path to the temporary directory used by gwvolman."""
         if self._tmpdir_mount is None:
-            c = self.docker_client.containers.get("celery_worker")
+            service = self.docker_client.services.get("wt_celery_worker")
             tmpdir = tempfile.gettempdir()
+            mounts = service.attrs["Spec"]["TaskTemplate"]["ContainerSpec"]["Mounts"]
             self._tmpdir_mount = next(
-                (_["Source"] for _ in c.attrs["Mounts"] if _["Destination"] == tmpdir),
+                (_["Source"] for _ in mounts if _["Target"] == tmpdir),
                 "/tmp"
             )
         return self._tmpdir_mount

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -19,7 +19,7 @@ import docker
 import datetime
 import dateutil.relativedelta as rel
 
-from .constants import LICENSE_PATH, MOUNTPOINTS, REPO2DOCKER_VERSION
+from .constants import LICENSE_PATH, MOUNTPOINTS, REPO2DOCKER_VERSION, VOLUMES_ROOT
 from .lib.stats_collector import DockerStatsCollectorThread
 
 DOCKER_URL = os.environ.get("DOCKER_URL", "unix://var/run/docker.sock")
@@ -244,7 +244,7 @@ def _launch_container(volume_info, container_config):
     #                        target=container_config.target_mount)
     # ]
 
-    source_mount = volume_info["mountPoint"]
+    source_mount = os.path.join(VOLUMES_ROOT, "mountpoints", volume_info["volumeName"])
     mounts = []
     volumes = _get_container_volumes(source_mount, container_config, MOUNTPOINTS)
     for source in volumes:
@@ -338,7 +338,7 @@ class DummyTask:
     canceled = False
 
 
-def stop_container(container):
+def stop_container(container: docker.models.containers.Container):
     try:
         container.stop()
     except requests.exceptions.ReadTimeout:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@ pytest-celery
 httmock
 mock
 flake8
-codecov


### PR DESCRIPTION
Summary of changes:
1. Most logic/code related to mounting fses was moved to https://github.com/whole-tale/girderfs/pull/38
2. Mounting/unmounting is done via running/stopping a dedicated sidecar container
3. An assumption that `celery_worker` is running in a regular container, were replaced by the notion of `celery_worker` running as a swarm service (see changes in `gwvolman/utils.py`)
4. WT deployments rely upon specific queues being defined. Up till now, that was handled by manually passing their names in `run_worker.sh` on each node. With this PR, everything happens automatically (see changes in `gwvolman/__init__.py`) 

Fixes https://github.com/whole-tale/gwvolman/issues/196