### PR TITLE
Add a retry for connection error in fs_container

### DIFF
--- a/gwvolman/tests/test_recorded_run.py
+++ b/gwvolman/tests/test_recorded_run.py
@@ -116,7 +116,7 @@ def test_recorded_run(
     ) as mock_dep, mock.patch("builtins.open", mock.mock_open()), mock.patch(
         "docker.from_env", return_value=mock.MagicMock()
     ) as mock_docker, mock.patch(
-        "requests.post", return_value=mock.MagicMock()
+        "requests.Session.post", return_value=mock.MagicMock()
     ) as mock_post, mock.patch(
         "requests.delete", return_value=mock.MagicMock()
     ) as mock_delete:
@@ -167,7 +167,7 @@ def test_recorded_run(
         ) as mock_dep, mock.patch("builtins.open", mock.mock_open()), mock.patch(
             "docker.from_env", return_value=mock.MagicMock()
         ) as mock_docker, mock.patch(
-            "requests.post", return_value=mock.MagicMock()
+            "requests.Session.post", return_value=mock.MagicMock()
         ) as mock_post, mock.patch(
             "requests.delete", return_value=mock.MagicMock()
         ) as mock_delete:

--- a/gwvolman/tests/test_volumes.py
+++ b/gwvolman/tests/test_volumes.py
@@ -41,7 +41,7 @@ def test_create_volume(gak, info, osmk, nu):
     create_volume.job_manager = mock.MagicMock()
 
     with mock.patch("docker.from_env") as mock_docker, mock.patch(
-        "requests.post"
+        "requests.Session.post"
     ) as mock_post:
         mock_docker.return_value = mock.MagicMock()
         # mock docker info


### PR DESCRIPTION
Should fix intermittent failures we've seen on slower systems, e.g.

```
[2023-06-12 14:43:54,764: WARNING/ForkPoolWorker-1] Sending payload to WT Filesystem container...
[2023-06-12 14:43:54,788: ERROR/ForkPoolWorker-1] Task gwvolman.tasks.create_volume[fbf6448c-f851-497d-ac4a-3782e8e46ccb] raised unexpected: ConnectionError(MaxRetryError("HTTPConnectionPool(host='6481e4c123e04ab3d99445bd_cawillis_foomex', port=8888): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fec583f2dd0>: Failed to establish a new connection: [Errno 111] Connection refused'))"))
Traceback (most recent call last):
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/util/connection.py", line 95, in create_connection
    raise err
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/util/connection.py", line 85, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 703, in urlopen
    httplib_response = self._make_request(
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 398, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/connection.py", line 244, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/usr/lib/python3.10/http/client.py", line 1282, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1328, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1277, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1037, in _send_output
    self.send(msg)
  File "/usr/lib/python3.10/http/client.py", line 975, in send
    self.connect()
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/connection.py", line 205, in connect
    conn = self._new_conn()
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/connection.py", line 186, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7fec583f2dd0>: Failed to establish a new connection: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/wtuser/venv/lib/python3.10/site-packages/requests/adapters.py", line 487, in send
    resp = conn.urlopen(
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    retries = retries.increment(
  File "/home/wtuser/venv/lib/python3.10/site-packages/urllib3/util/retry.py", line 592, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='6481e4c123e04ab3d99445bd_cawillis_foomex', port=8888): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fec583f2dd0>: Failed to establish a new connection: [Errno 111] Connection refused'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/wtuser/venv/lib/python3.10/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/wtuser/venv/lib/python3.10/site-packages/girder_worker/task.py", line 154, in __call__
    results = super(Task, self).__call__(*_t_args, **_t_kwargs)
  File "/home/wtuser/venv/lib/python3.10/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/gwvolman/gwvolman/tasks.py", line 81, in create_volume
    FSContainer.mount(fs_sidecar, payload)
  File "/gwvolman/gwvolman/fs_container.py", line 60, in mount
    response = requests.post(
  File "/home/wtuser/venv/lib/python3.10/site-packages/requests/api.py", line 115, in post
    return request("post", url, data=data, json=json, **kwargs)
  File "/home/wtuser/venv/lib/python3.10/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/wtuser/venv/lib/python3.10/site-packages/requests/sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/wtuser/venv/lib/python3.10/site-packages/requests/sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "/home/wtuser/venv/lib/python3.10/site-packages/requests/adapters.py", line 520, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='6481e4c123e04ab3d99445bd_cawillis_foomex', port=8888): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fec583f2dd0>: Failed to establish a new connection: [Errno 111] Connection refused'))
```