### PR TITLE
Ensure that mounted workspace is rrun's working directory

### DIFF
--- a/gwvolman/tests/test_recorded_run.py
+++ b/gwvolman/tests/test_recorded_run.py
@@ -58,6 +58,7 @@ RPZ_RUN_CALL = mock.call(
         },
     },
     name="rrun-123456",
+    working_dir="/work/workspace",
 )
 CPR_RUN_CALL = mock.call(
     image="wholetale/wt-cpr:latest",

--- a/gwvolman/utils.py
+++ b/gwvolman/utils.py
@@ -383,7 +383,8 @@ def _recorded_run(cli, mountpoint, container_config, tag, entrypoint, name, task
         command=run_cmd,
         detach=True,
         name=name,
-        volumes=volumes
+        volumes=volumes,
+        working_dir=os.path.join(container_config.target_mount, "workspace"),
     )
 
     logging_thread = threading.Thread(


### PR DESCRIPTION
This is required when Tale uses it's own Dockerfile.